### PR TITLE
Allow zero or negative rate change percentages

### DIFF
--- a/src/App.test.js
+++ b/src/App.test.js
@@ -1,8 +1,50 @@
-import { render, screen } from '@testing-library/react';
-import App from './App';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react'
+import Calculator from './Components/Calculator/calculator'
 
-test('renders learn react link', () => {
-  render(<App />);
-  const linkElement = screen.getByText(/learn react/i);
-  expect(linkElement).toBeInTheDocument();
-});
+const fillRequiredFields = (rateChange) => {
+  const [chargesInput, monthlyUsageInput, annualUsageInput, rateChangeInput, minimalRateInput] = screen.getAllByRole('spinbutton')
+
+  fireEvent.change(chargesInput, { target: { value: '120' } })
+  fireEvent.change(monthlyUsageInput, { target: { value: '600' } })
+  fireEvent.change(annualUsageInput, { target: { value: '7200' } })
+  fireEvent.change(rateChangeInput, { target: { value: rateChange } })
+  fireEvent.change(minimalRateInput, { target: { value: '3' } })
+}
+
+const submitForm = () => {
+  const button = screen.getByRole('button', { name: /calculate rate/i })
+  fireEvent.click(button)
+}
+
+const expectProjectedBillToBe = async (value) => {
+  await waitFor(() => {
+    expect(screen.getByText(/the monthly bill with change is/i)).toHaveTextContent(`$ ${value}`)
+  })
+}
+
+test('calculates projected monthly bill with a 10% increase', async () => {
+  render(<Calculator />)
+
+  fillRequiredFields('10')
+  submitForm()
+
+  await expectProjectedBillToBe('132.00')
+})
+
+test('calculates projected monthly bill with no percentage change', async () => {
+  render(<Calculator />)
+
+  fillRequiredFields('0')
+  submitForm()
+
+  await expectProjectedBillToBe('120.00')
+})
+
+test('calculates projected monthly bill with a 5% decrease', async () => {
+  render(<Calculator />)
+
+  fillRequiredFields('-5')
+  submitForm()
+
+  await expectProjectedBillToBe('114.00')
+})

--- a/src/Components/Calculator/calculator.js
+++ b/src/Components/Calculator/calculator.js
@@ -76,9 +76,11 @@ const Calculator = () => {
   }
 
   function calculateAnnualUsage() {
-    if (rate && annualUsage > 0 && scePecentage > 0) {
+    const parsedPercentage = parseFloat(scePecentage)
+
+    if (rate && annualUsage > 0 && !Number.isNaN(parsedPercentage)) {
       const avgMonthlyBill = (annualUsage * parseFloat(rate)) / 12
-      const projectedFutureAvg = avgMonthlyBill * (scePecentage / 100)
+      const projectedFutureAvg = avgMonthlyBill * (parsedPercentage / 100)
       const totalProjectedMontlyBill = avgMonthlyBill + projectedFutureAvg
 
       setAvgPerMonthCost(avgMonthlyBill.toFixed(2))
@@ -186,7 +188,7 @@ const Calculator = () => {
     </div>
 
     <div className="form-group">
-      <label><PercentIcon /> Rate Increase Percentage:</label>
+      <label><PercentIcon /> Rate Change Percentage (increase or decrease):</label>
       <input type="number" value={scePecentage} onChange={(e) => setScePecentage(e.target.value)} required />
     </div>
 
@@ -227,8 +229,8 @@ const Calculator = () => {
             </ListItem>
             <Divider component="li" />
             <ListItem>
-              <ListItemText primary={`The monthly bill with increase is $ ${projectedMonthlyBill}`}/>
-              <Typography variant="p" gutterBottom>($ {avgPerMonthCost} + {scePecentage} / 100)</Typography>
+              <ListItemText primary={`The monthly bill with change is $ ${projectedMonthlyBill}`}/>
+              <Typography variant="p" gutterBottom>({avgPerMonthCost} × (1 + {scePecentage} / 100))</Typography>
             </ListItem>
             <Divider component="li" />
             {/* <ListItem><ListItemText primary="Projected Monthly Electric Bills (Next 10 Years)" /></ListItem>

--- a/src/setupTests.js
+++ b/src/setupTests.js
@@ -3,3 +3,17 @@
 // expect(element).toHaveTextContent(/react/i)
 // learn more: https://github.com/testing-library/jest-dom
 import '@testing-library/jest-dom';
+
+class ResizeObserver {
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+}
+
+if (typeof window !== 'undefined' && !window.ResizeObserver) {
+  window.ResizeObserver = ResizeObserver
+}
+
+if (typeof global !== 'undefined' && !global.ResizeObserver) {
+  global.ResizeObserver = ResizeObserver
+}


### PR DESCRIPTION
## Summary
- allow the calculator to accept zero or negative rate change percentages and update the UI copy accordingly
- add tests to confirm projected monthly bills for positive, zero, and negative SCE rate changes
- provide a ResizeObserver polyfill so the chart renders during tests

## Testing
- npm test -- --watchAll=false

------
https://chatgpt.com/codex/tasks/task_e_68d198ba4d4c832792e3f98bab5bbcd1