### PR TITLE
Refine bill projection chart with savings visualization

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -1,38 +1,18 @@
-.App {
-  text-align: center;
+* {
+  box-sizing: border-box;
 }
 
-.App-logo {
-  height: 40vmin;
-  pointer-events: none;
+body {
+  margin: 0;
+  font-family: 'Inter', 'Segoe UI', 'Helvetica Neue', Arial, sans-serif;
+  background: radial-gradient(circle at 20% 20%, #e0f2fe 0%, #e2e8f0 35%, #fef3c7 100%);
+  min-height: 100vh;
 }
 
-@media (prefers-reduced-motion: no-preference) {
-  .App-logo {
-    animation: App-logo-spin infinite 20s linear;
-  }
-}
-
-.App-header {
-  background-color: #282c34;
+.app-shell {
   min-height: 100vh;
   display: flex;
-  flex-direction: column;
-  align-items: center;
   justify-content: center;
-  font-size: calc(10px + 2vmin);
-  color: white;
-}
-
-.App-link {
-  color: #61dafb;
-}
-
-@keyframes App-logo-spin {
-  from {
-    transform: rotate(0deg);
-  }
-  to {
-    transform: rotate(360deg);
-  }
+  align-items: flex-start;
+  padding: clamp(32px, 6vw, 72px) clamp(16px, 5vw, 64px);
 }

--- a/src/App.js
+++ b/src/App.js
@@ -1,12 +1,12 @@
-import './App.css';
-import Calculator from './Components/Calculator/calculator';
+import './App.css'
+import Calculator from './Components/Calculator/calculator'
 
 function App() {
   return (
-    <>
+    <div className="app-shell">
       <Calculator />
-    </>
+    </div>
   )
 }
 
-export default App;
+export default App

--- a/src/Components/Calculator/styles.css
+++ b/src/Components/Calculator/styles.css
@@ -1,84 +1,85 @@
-/* Global Styles */
-* {
-  margin: 0;
-  padding: 0;
-  box-sizing: border-box;
+:root {
+  font-family: 'Inter', 'Segoe UI', 'Helvetica Neue', Arial, sans-serif;
+  color-scheme: light;
 }
 
 body {
-  font-family: 'Arial', sans-serif;
-  background: linear-gradient(to bottom, #F0F8FF, #FFF8E1); /* Soft blue to warm yellow */
-  color: #333; /* Dark text for readability */
-  font-family: 'Arial', sans-serif;
   margin: 0;
-  padding: 0;
+  font-family: 'Inter', 'Segoe UI', 'Helvetica Neue', Arial, sans-serif;
+  color: #0f172a;
 }
 
-/* Main Container */
 .calculator-container {
   display: flex;
   flex-direction: column;
-  justify-content: flex-start;
-  padding: 30px;
-  margin: 0 auto;
-  background-color: #fff;
-  border-radius: 10px;
-  max-width: 900px;
+  gap: 32px;
   width: 100%;
+  max-width: 1100px;
+  margin: 0 auto;
+  color: #0f172a;
 }
 
 .calculator-header {
   text-align: center;
-  margin-bottom: 20px;
-}
-
-h2 {
-  font-size: 26px;
-  color: #333;
-  margin-bottom: 15px;
-}
-
-button {
-  padding: 12px 20px;
-  background-color: #007bff;
-  color: white;
-  border: none;
-  border-radius: 4px;
-  cursor: pointer;
-  font-size: 16px;
-  transition: background-color 0.3s ease;
-  width: 100%;
-}
-
-button:hover {
-  background-color: #0056b3;
-}
-
-button.reset {
-  background-color: #dc3545;
-}
-
-button.reset:hover {
-  background-color: #c82333;
-}
-
-button.sunrun-calculate-btn {
-  background-color: #28a745;
-  margin-top: 10px;
-  max-width: 600px;
-  width: 47%;
-}
-
-button.sunrun-calculate-btn:hover {
-  background-color: #218838;
-}
-
-/* Form Layout */
-.calculator-form {
   display: flex;
   flex-direction: column;
-  gap: 20px;
-  margin-bottom: 20px;
+  gap: 12px;
+}
+
+.calculator-badge {
+  align-self: center;
+  background: rgba(37, 99, 235, 0.12);
+  color: #1d4ed8;
+  font-weight: 600;
+  font-size: 0.85rem;
+  padding: 6px 14px;
+  border-radius: 999px;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+}
+
+.calculator-header h1 {
+  font-size: clamp(2rem, 2.8vw, 2.75rem);
+  font-weight: 700;
+  margin: 0;
+}
+
+.calculator-header p {
+  max-width: 640px;
+  margin: 0 auto;
+  color: #475569;
+  font-size: 1rem;
+  line-height: 1.6;
+}
+
+.calculator-grid {
+  display: grid;
+  gap: 24px;
+  grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
+}
+
+.surface-card {
+  background: rgba(255, 255, 255, 0.92);
+  border-radius: 24px;
+  padding: clamp(24px, 2.8vw, 32px);
+  border: 1px solid rgba(148, 163, 184, 0.25);
+  box-shadow: 0 25px 55px rgba(15, 23, 42, 0.12);
+  backdrop-filter: blur(16px);
+}
+
+.form-header {
+  margin-bottom: 18px;
+}
+
+.form-header h3 {
+  margin: 0 0 6px;
+  font-size: 1.4rem;
+}
+
+.form-header p {
+  margin: 0;
+  color: #64748b;
+  font-size: 0.95rem;
 }
 
 .form-group {
@@ -87,115 +88,295 @@ button.sunrun-calculate-btn:hover {
   gap: 8px;
 }
 
+.form-group + .form-group {
+  margin-top: 16px;
+}
+
 .form-group label {
-  font-size: 16px;
-  color: #333;
+  font-weight: 600;
+  color: #0f172a;
+  display: flex;
+  align-items: center;
+  gap: 8px;
 }
 
 .form-group input {
-  padding: 12px;
-  font-size: 16px;
-  border: 1px solid #ddd;
-  border-radius: 4px;
-  width: 100%;
-  max-width: 400px;
-  transition: border-color 0.3s ease;
+  padding: 14px 16px;
+  font-size: 1rem;
+  border-radius: 16px;
+  border: 1px solid rgba(148, 163, 184, 0.4);
+  transition: border-color 0.3s ease, box-shadow 0.3s ease;
+  background: rgba(248, 250, 252, 0.9);
 }
 
 .form-group input:focus {
   outline: none;
-  border-color: #007bff;
+  border-color: #2563eb;
+  box-shadow: 0 0 0 4px rgba(37, 99, 235, 0.15);
 }
 
 .button-group {
   display: flex;
-  gap: 12px;
   flex-wrap: wrap;
+  gap: 12px;
+  margin-top: 24px;
+}
+
+button {
+  border: none;
+  border-radius: 999px;
+  padding: 13px 22px;
+  font-weight: 600;
+  font-size: 1rem;
+  cursor: pointer;
+  transition: transform 0.2s ease, box-shadow 0.2s ease, background 0.2s ease;
 }
 
 .button-group button {
-  width: 48%;
-  max-width: 250px;
+  flex: 1 1 180px;
+  background: linear-gradient(135deg, #2563eb, #1d4ed8);
+  color: #fff;
+  box-shadow: 0 15px 30px rgba(37, 99, 235, 0.25);
+}
+
+.button-group button:hover {
+  transform: translateY(-2px);
+  box-shadow: 0 18px 38px rgba(37, 99, 235, 0.28);
+}
+
+.button-group .reset {
+  background: rgba(15, 23, 42, 0.08);
+  color: #0f172a;
+  box-shadow: none;
+}
+
+.button-group .reset:hover {
+  background: rgba(15, 23, 42, 0.12);
+  box-shadow: none;
+}
+
+.result-panel {
+  display: flex;
+  flex-direction: column;
+  gap: 20px;
+}
+
+.result-header h3 {
+  margin: 0 0 6px;
+  font-size: 1.35rem;
+}
+
+.result-header p {
+  margin: 0;
+  color: #64748b;
+}
+
+.result-item .MuiListItemText-primary {
+  font-weight: 600;
+  color: #0f172a;
+  font-size: 1.05rem;
+}
+
+.result-item .MuiListItemText-secondary {
+  margin-top: 4px;
+  color: #64748b;
+  font-size: 0.9rem;
 }
 
 .sunrun-input-container {
-  text-align: center;
-  margin-top: 30px;
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+  padding: 18px 20px;
+  border-radius: 18px;
+  background: linear-gradient(135deg, rgba(199, 210, 254, 0.35), rgba(191, 219, 254, 0.35));
+  border: 1px solid rgba(148, 163, 184, 0.2);
 }
 
-.sunrun-input-container input {
-  padding: 12px;
+.sunrun-input-row {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  align-items: flex-start;
+}
+
+.sunrun-input-row label {
+  font-weight: 600;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.sunrun-input-row input {
   width: 100%;
-  max-width: 400px;
-  font-size: 16px;
+  max-width: 240px;
+  padding: 12px 14px;
+  border-radius: 14px;
+  border: 1px solid rgba(148, 163, 184, 0.35);
+  background: rgba(255, 255, 255, 0.9);
+}
+
+.sunrun-input-row input:focus {
+  outline: none;
+  border-color: #22c55e;
+  box-shadow: 0 0 0 4px rgba(34, 197, 94, 0.15);
+}
+
+.sunrun-calculate-btn {
+  align-self: flex-start;
+  background: linear-gradient(135deg, #22c55e, #16a34a);
+  color: #fff;
+  box-shadow: 0 12px 24px rgba(34, 197, 94, 0.28);
+}
+
+.sunrun-calculate-btn:hover {
+  transform: translateY(-2px);
+  box-shadow: 0 16px 32px rgba(34, 197, 94, 0.32);
 }
 
 .warning-label {
-  font-weight: bold;
-  margin-bottom: 10px;
+  font-size: 0.95rem;
+  font-weight: 600;
+  color: #166534;
 }
 
-.result-container {
-  margin-top: 30px;
+.empty-state {
+  padding: 26px;
+  border-radius: 18px;
+  background: rgba(248, 250, 252, 0.75);
+  border: 1px dashed rgba(148, 163, 184, 0.35);
+  text-align: center;
 }
 
-.mobile-graph-layout {
-  margin-top: 20px;
+.empty-state h4 {
+  margin: 0 0 10px;
+  font-size: 1.25rem;
+}
+
+.empty-state p {
+  margin: 0;
+  color: #64748b;
+}
+
+.chart-card {
+  display: flex;
+  flex-direction: column;
+  gap: 20px;
+  background: radial-gradient(circle at top right, rgba(59, 130, 246, 0.08), transparent 55%);
+}
+
+.chart-header h3 {
+  margin: 0;
+  font-size: 1.4rem;
+}
+
+.chart-header p {
+  margin: 6px 0 0;
+  color: #64748b;
+}
+
+.chart-wrapper {
   width: 100%;
+  height: 100%;
+  padding: 8px 0 4px;
 }
 
-/* Result List Styling */
-.list-item-text {
-  font-size: 16px;
-  color: #333;
+.chart-tooltip {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  min-width: 200px;
+  padding: 14px 16px;
+  border-radius: 16px;
+  background: rgba(15, 23, 42, 0.9);
+  color: #f8fafc;
+  box-shadow: 0 18px 45px rgba(15, 23, 42, 0.25);
 }
 
-/* Mobile-specific styles */
-@media (max-width: 600px) {
-  .mobile-graph-layout {
-    width: 100%;  /* Ensure it takes full width */
-    margin-top: 20px;  /* Optional: Add some margin for better spacing */
-  }
+.chart-tooltip__label {
+  margin: 0;
+  font-size: 0.9rem;
+  letter-spacing: 0.03em;
+  text-transform: uppercase;
+  color: rgba(226, 232, 240, 0.85);
 }
 
-/* Responsive Layout */
-@media (min-width: 600px) {
+.chart-tooltip__item {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  font-size: 0.95rem;
+  position: relative;
+  padding-left: 18px;
+  gap: 16px;
+}
+
+.chart-tooltip__item::before {
+  content: '';
+  position: absolute;
+  left: 0;
+  top: 50%;
+  transform: translateY(-50%);
+  width: 10px;
+  height: 10px;
+  border-radius: 999px;
+  background: var(--color, #2563eb);
+  box-shadow: 0 0 0 3px rgba(148, 163, 184, 0.25);
+}
+
+.chart-tooltip__item strong {
+  font-size: 1rem;
+  letter-spacing: 0.02em;
+}
+
+.chart-tooltip__savings {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-top: 8px;
+  padding: 10px 12px;
+  border-radius: 14px;
+  background: rgba(34, 197, 94, 0.12);
+  color: #4ade80;
+  font-weight: 600;
+  font-size: 0.95rem;
+}
+
+.recharts-default-legend {
+  padding-right: 14px !important;
+}
+
+.recharts-legend-item-text {
+  color: #0f172a !important;
+  font-weight: 600;
+  letter-spacing: 0.01em;
+}
+
+@media (max-width: 768px) {
   .calculator-container {
-    padding: 40px;
+    padding: 0 4px;
   }
 
-  .form-group input,
-  .button-group button {
-    width: 48%;
-    max-width: 300px;
-  }
-
-  .result-container {
-    width: 100%;
+  .surface-card {
+    border-radius: 20px;
+    padding: 22px;
   }
 
   .button-group {
-    justify-content: space-between;
+    flex-direction: column;
+  }
+
+  .button-group button {
+    width: 100%;
+  }
+
+  .sunrun-input-row input {
+    max-width: 100%;
   }
 }
 
-@media (min-width: 900px) {
+@media (min-width: 1100px) {
   .calculator-container {
-    max-width: 900px;
-    margin: 40px auto;
-  }
-
-  .form-group input,
-  .button-group button {
-    width: 48%;
-  }
-
-  .result-container {
-    margin-top: 50px;
-  }
-
-  .mobile-graph-layout {
-    width: 100%;
-    margin-top: 30px;
+    padding: 0 10px;
   }
 }


### PR DESCRIPTION
## Summary
- replace the basic line chart with a composed visualization that layers monthly savings shading and richer axes formatting
- introduce a bespoke tooltip that highlights Sunrun vs. SCE projections along with annualized savings context
- polish chart styling with gradient accents, legend tweaks, and tooltip theming to match the refreshed calculator surface

## Testing
- npm test -- --watchAll=false

------
https://chatgpt.com/codex/tasks/task_e_68d8556b0bcc8327ae6fa65712e82eab