### PR TITLE
Polish calculator UI with immersive insights

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -1,38 +1,58 @@
-.App {
-  text-align: center;
+* {
+  box-sizing: border-box;
 }
 
-.App-logo {
-  height: 40vmin;
-  pointer-events: none;
+body {
+  margin: 0;
+  font-family: 'Inter', 'Segoe UI', 'Helvetica Neue', Arial, sans-serif;
+  background: radial-gradient(circle at 20% 20%, #e0f2fe 0%, #e2e8f0 35%, #fef3c7 100%);
+  min-height: 100vh;
 }
 
-@media (prefers-reduced-motion: no-preference) {
-  .App-logo {
-    animation: App-logo-spin infinite 20s linear;
-  }
-}
-
-.App-header {
-  background-color: #282c34;
+.app-shell {
+  position: relative;
   min-height: 100vh;
   display: flex;
-  flex-direction: column;
-  align-items: center;
   justify-content: center;
-  font-size: calc(10px + 2vmin);
-  color: white;
+  align-items: flex-start;
+  padding: clamp(32px, 6vw, 72px) clamp(16px, 5vw, 64px);
+  overflow: hidden;
 }
 
-.App-link {
-  color: #61dafb;
+.app-shell::before,
+.app-shell::after {
+  content: '';
+  position: absolute;
+  border-radius: 50%;
+  filter: blur(90px);
+  opacity: 0.45;
+  transform: translate3d(0, 0, 0);
+  animation: floatGlow 18s ease-in-out infinite;
 }
 
-@keyframes App-logo-spin {
-  from {
-    transform: rotate(0deg);
+.app-shell::before {
+  top: -120px;
+  left: -180px;
+  width: 420px;
+  height: 420px;
+  background: radial-gradient(circle, rgba(37, 99, 235, 0.35) 0%, rgba(37, 99, 235, 0) 65%);
+}
+
+.app-shell::after {
+  bottom: -160px;
+  right: -120px;
+  width: 360px;
+  height: 360px;
+  background: radial-gradient(circle, rgba(16, 185, 129, 0.3) 0%, rgba(16, 185, 129, 0) 70%);
+  animation-delay: -6s;
+}
+
+@keyframes floatGlow {
+  0%,
+  100% {
+    transform: translate3d(0, 0, 0) scale(1);
   }
-  to {
-    transform: rotate(360deg);
+  50% {
+    transform: translate3d(12px, -18px, 0) scale(1.05);
   }
 }

--- a/src/App.js
+++ b/src/App.js
@@ -1,12 +1,12 @@
-import './App.css';
-import Calculator from './Components/Calculator/calculator';
+import './App.css'
+import Calculator from './Components/Calculator/calculator'
 
 function App() {
   return (
-    <>
+    <div className="app-shell">
       <Calculator />
-    </>
+    </div>
   )
 }
 
-export default App;
+export default App

--- a/src/Components/Calculator/calculator.js
+++ b/src/Components/Calculator/calculator.js
@@ -1,6 +1,5 @@
 import React, { useState, useEffect } from 'react'
-//import { LineChart } from '@mui/x-charts/LineChart'
-import { LineChart, Line, XAxis, YAxis, CartesianGrid, Tooltip, Legend, ResponsiveContainer } from 'recharts'
+import { ComposedChart, Line, Area, XAxis, YAxis, CartesianGrid, Tooltip, Legend, ResponsiveContainer } from 'recharts'
 import AttachMoneyIcon from '@mui/icons-material/AttachMoney'
 import BoltTwoToneIcon from '@mui/icons-material/BoltTwoTone'
 import SolarPowerTwoToneIcon from '@mui/icons-material/SolarPowerTwoTone'
@@ -10,41 +9,89 @@ import ListItem from '@mui/material/ListItem'
 import ListItemText from '@mui/material/ListItemText'
 import PowerOutlinedIcon from '@mui/icons-material/PowerOutlined'
 import Box from '@mui/material/Box'
-import Button from '@mui/material/Button'
-import Typography from '@mui/material/Typography'
-import Modal from '@mui/material/Modal'
 import PercentIcon from '@mui/icons-material/Percent'
 import './styles.css'  // Importing the updated CSS file
 
 const xYearsLabel = ["2025", "2026", "2027", "2028", "2029", "2030", "2031", "2032", "2033", "2034", "2035"]
 
-const style = {
+const listStyles = {
   py: 0,
   width: '100%',
-  borderRadius: 2,
-  border: '1px solid',
-  borderColor: 'divider',
-  backgroundColor: 'background.paper',
-  marginBottom: '20px',
-  maxWidth: '600px'
+  borderRadius: 3,
+  border: '1px solid rgba(148, 163, 184, 0.35)',
+  backgroundColor: 'rgba(255,255,255,0.85)',
+  boxShadow: '0 18px 45px rgba(15, 23, 42, 0.12)',
+  backdropFilter: 'blur(14px)'
 }
 
-const textBoxStyle = {
-  display: 'flex',
-  justifyContent: 'center',
-  alignItems: 'center',
+const listWrapperStyles = {
+  width: '100%'
 }
-// const modalStyle = {
-//   position: 'absolute',
-//   top: '50%',
-//   left: '50%',
-//   transform: 'translate(-50%, -50%)',
-//   width: 400,
-//   backgroundColor: 'background.paper',
-//   border: '2px solid #000',
-//   boxShadow: 24,
-//   p: 4
-// }
+const currencyFormatter = (value) => {
+  if (value === 0) {
+    return '$0'
+  }
+
+  return `$${value.toLocaleString(undefined, { minimumFractionDigits: 0, maximumFractionDigits: 0 })}`
+}
+
+const formatCurrency = (value, options = { minimumFractionDigits: 0, maximumFractionDigits: 0 }) => {
+  if (!Number.isFinite(value)) {
+    return '—'
+  }
+
+  return `$${value.toLocaleString(undefined, options)}`
+}
+
+const formatRate = (value) => {
+  if (!Number.isFinite(value)) {
+    return '—'
+  }
+
+  return `$${value.toFixed(2)}`
+}
+
+const formatPercentage = (value, digits = 1) => {
+  if (!Number.isFinite(value)) {
+    return '—'
+  }
+
+  return `${value.toFixed(digits)}%`
+}
+
+const ChartTooltip = ({ active, payload, label }) => {
+  if (!active || !payload || payload.length === 0) {
+    return null
+  }
+
+  const sunrun = payload.find((item) => item.dataKey === 'SunRun')
+  const sce = payload.find((item) => item.dataKey === 'SCE')
+  const savings = payload.find((item) => item.dataKey === 'Savings')
+
+  return (
+    <div className="chart-tooltip">
+      <p className="chart-tooltip__label">{label}</p>
+      {sunrun && (
+        <div className="chart-tooltip__item" style={{ '--color': sunrun.color }}>
+          <span>Sunrun</span>
+          <strong>${sunrun.value.toFixed(2)}</strong>
+        </div>
+      )}
+      {sce && (
+        <div className="chart-tooltip__item" style={{ '--color': sce.color }}>
+          <span>SCE</span>
+          <strong>${sce.value.toFixed(2)}</strong>
+        </div>
+      )}
+      {savings?.value != null && (
+        <div className="chart-tooltip__savings">
+          <span>Yearly savings</span>
+          <strong>${(savings.value * 12).toFixed(2)}</strong>
+        </div>
+      )}
+    </div>
+  )
+}
 
 const Calculator = () => {
   const [charges, setCharges] = useState('')
@@ -57,6 +104,13 @@ const Calculator = () => {
   const [projectedFutureRateIncrease, setProjectedFutureRateIncrease] = useState('0.00')
   const [avgPerMonthCost, setAvgPerMonthCost] = useState(null)
   const [projectedBills, setProjectedBills] = useState({ sunrunBills: [], sceBills: [] })
+  const [isDesktop, setIsDesktop] = useState(() => {
+    if (typeof window === 'undefined') {
+      return true
+    }
+
+    return window.innerWidth >= 768
+  })
   // const [open, setOpen] = useState(false)
   
   // const handleOpen = () => setOpen(true)
@@ -126,12 +180,26 @@ const Calculator = () => {
       calculateAnnualUsage() // Only calculate annual usage if conditions are met
     }
   }, [rate, annualUsage]); // Remove calculateAnnualUsage and avgPerMonthCost from the dependencies
-  
+
   useEffect(() => {
     if (avgPerMonthCost) {
       generateProjectedBills(parseFloat(avgPerMonthCost), parseFloat(sunRunAnnualRateIncrease)); // Now, handle projected bills based on avgPerMonthCost in a separate effect
     }
   }, [avgPerMonthCost]);
+
+  useEffect(() => {
+    if (typeof window === 'undefined') {
+      return undefined
+    }
+
+    const handleResize = () => {
+      setIsDesktop(window.innerWidth >= 768)
+    }
+
+    window.addEventListener('resize', handleResize)
+
+    return () => window.removeEventListener('resize', handleResize)
+  }, [])
 
   const handleSubmit = (e) => {
     e.preventDefault()
@@ -155,125 +223,277 @@ const Calculator = () => {
     setScePecentage('')
     setSunRunAnnualRateIncrease('0.00')
     setRate(null)
-    setProjectedFutureRateIncrease(null)
+    setProjectedFutureRateIncrease('0.00')
     setAvgPerMonthCost(null)
+    setProjectedMonthlyBill(null)
     setProjectedBills({ sunrunBills: [], sceBills: [] })
   }
 
+  const chartData = xYearsLabel
+    .map((year, index) => {
+      const sunrunBill = projectedBills.sunrunBills[index]
+      const sceBill = projectedBills.sceBills[index]
+
+      if (!sunrunBill || !sceBill) {
+        return null
+      }
+
+      const sunrunValue = parseFloat(sunrunBill)
+      const sceValue = parseFloat(sceBill)
+
+      return {
+        year,
+        SunRun: sunrunValue,
+        SCE: sceValue,
+        Savings: Math.max(sceValue - sunrunValue, 0)
+      }
+    })
+    .filter(Boolean)
+
+  const parsedRate = rate !== null ? parseFloat(rate) : null
+  const avgMonthlyCostValue = avgPerMonthCost ? parseFloat(avgPerMonthCost) : null
+  const projectedMonthlyBillValue = projectedMonthlyBill ? parseFloat(projectedMonthlyBill) : null
+  const sunrunMonthlyValue = sunRunAnnualRateIncrease ? parseFloat(sunRunAnnualRateIncrease) : null
+  const sunrunReady = Number.isFinite(sunrunMonthlyValue) && sunrunMonthlyValue > 0
+  const firstYearSunrunTotal = sunrunReady ? sunrunMonthlyValue * 12 : null
+  const firstYearSceTotal = projectedMonthlyBillValue ? projectedMonthlyBillValue * 12 : null
+  const firstYearSavings = sunrunReady && chartData.length > 0 ? (chartData[0].Savings || 0) * 12 : null
+  const lifetimeSavings = sunrunReady && chartData.length > 0
+    ? chartData.reduce((acc, point) => acc + (point.Savings || 0) * 12, 0)
+    : null
+  const totalSceSpend = chartData.length > 0
+    ? chartData.reduce((acc, point) => acc + point.SCE * 12, 0)
+    : null
+  const savingsPercentage = lifetimeSavings && totalSceSpend
+    ? (lifetimeSavings / totalSceSpend) * 100
+    : null
+  const bestSavingsYear = sunrunReady && chartData.length > 0
+    ? chartData.reduce(
+        (best, point) => {
+          const annualSavings = (point.Savings || 0) * 12
+          if (annualSavings > best.amount) {
+            return { year: point.year, amount: annualSavings }
+          }
+
+          return best
+        },
+        { year: chartData[0].year, amount: (chartData[0].Savings || 0) * 12 }
+      )
+    : null
+
   return (
-<div className="calculator-container">
-  <div className="calculator-header">
-    <h2>SCE Rate Calculator</h2>
-    {/* <Button onClick={handleOpen} color="error" variant="text">Important Notice</Button>
-    <Modal open={open} onClose={handleClose}>
-      <Box sx={modalStyle}>
-        <Typography variant="h6">IMPORTANT NOTICE!</Typography>
-        <Typography sx={{ mt: 2 }}>
-          The rate increase for SCE is based on a 10.10% increase year over year for a period of ten years. 
-          Sunrun is set at 3.5% year over year. The SCE rates may not be accurate.
-        </Typography>
-      </Box>
-    </Modal> */}
-  </div>
+    <section className="calculator-container">
+      <div className="calculator-header">
+        <span className="calculator-badge">Energy insights</span>
+        <h1>Visualize your SCE costs with clarity</h1>
+        <p>Enter your recent charges and usage to calculate today&rsquo;s rate, then explore how future increases compare with a predictable Sunrun plan.</p>
+      </div>
 
-  <form className="calculator-form" onSubmit={handleSubmit}>
-    <div className="form-group">
-      <label><AttachMoneyIcon /> Monthly Charges</label>
-      <input type="number" step="0.01" value={charges} onChange={(e) => setCharges(e.target.value)} required />
-    </div>
-    
-    <div className="form-group">
-      <label><PowerOutlinedIcon /> Monthly kWh Usage</label>
-      <input type="number" value={usage} onChange={(e) => setUsage(e.target.value)} required />
-    </div>
-    
-    <div className="form-group">
-      <label><BoltTwoToneIcon /> Annual kWh Usage</label>
-      <input type="number" step="0.01" value={annualUsage} onChange={(e) => setAnnualUsage(e.target.value)} required />
-    </div>
-
-    <div className="form-group">
-      <label><PercentIcon /> Rate Change Percentage (increase or decrease):</label>
-      <input type="number" value={scePecentage} onChange={(e) => setScePecentage(e.target.value)} required />
-    </div>
-
-    <div className="form-group">
-      <label><PercentIcon /> Minimal Rate Percentage:</label>
-      <input type="number" value={projectedFutureRateIncrease} onChange={(e) => setProjectedFutureRateIncrease(e.target.value)} required />
-    </div>
-
-    <div className="button-group">
-      <button type="submit">Calculate Rate</button>
-      <button className="reset" type="button" onClick={handleReset}>Reset</button>
-    </div>
-
-  </form>
-
-  {rate !== null && (
-    <div className="sunrun-input-container">
-      <p className="warning-label">Please enter SunRun Monthly charge:</p>
-      <label><SolarPowerTwoToneIcon /> SunRun's Monthly Cost:</label>
-      <input type="number" step="0.01" value={sunRunAnnualRateIncrease} onChange={(e) => setSunRunAnnualRateIncrease(e.target.value)} />
-      <button className="sunrun-calculate-btn" onClick={handleSunRunMonthlyCost}>Calculate</button>
-    </div>
-  )}
-
-  <div className="result-container">
-    {rate !== null && (
-      <>
-        <Box sx={textBoxStyle}>
-          <List sx={style}>
-            <ListItem>
-              <ListItemText primary={`The rate is ${rate} per kWh.`} />
-              <Typography variant="p" gutterBottom>($ {charges} / {usage})</Typography>
-            </ListItem>
-            <Divider component="li" />
-            <ListItem>
-              <ListItemText primary={`The average monthly cost is ${avgPerMonthCost}`} />
-              <Typography variant="p" gutterBottom>({annualUsage} X $ {rate} / 12)</Typography>
-            </ListItem>
-            <Divider component="li" />
-            <ListItem>
-              <ListItemText primary={`The monthly bill with change is $ ${projectedMonthlyBill}`}/>
-              <Typography variant="p" gutterBottom>({avgPerMonthCost} × (1 + {scePecentage} / 100))</Typography>
-            </ListItem>
-            <Divider component="li" />
-            {/* <ListItem><ListItemText primary="Projected Monthly Electric Bills (Next 10 Years)" /></ListItem>
-            <Divider component="li" />
-            <ListItem><ListItemText primary="This graph demonstrates Sunrun's rate increase vs SCE rate increase over the years." /></ListItem> */}
-          </List> 
-        </Box>
-        <Typography variant="h5" gutterBottom>Projected monthly bill (10 years)</Typography>
-        <Typography variant="h6" gutterBottom>Sunrun's rate vs SCE rates.</Typography>
-
-        <div className="mobile-graph-layout">
-          <ResponsiveContainer width="100%" height={400}>
-            <LineChart data={projectedBills.sunrunBills.map((bill, index) => ({
-              year: xYearsLabel[index], 
-              SunRun: bill,             
-              SCE: projectedBills.sceBills[index]
-            }))}>
-              <CartesianGrid strokeDasharray="3 3" />
-              {/* Adjust the XAxis to rotate labels for better readability */}
-              <XAxis 
-                dataKey="year" 
-                tick={{ fontSize: 12 }} 
-                angle={-45}  // Rotate the labels for better fit
-                textAnchor="end" // Align text to end (makes the rotated text readable)
-              />
-              <YAxis tick={{ fontSize: 12 }} />
-              <Tooltip />
-              {/* Remove Legend on mobile to save space */}
-              {window.innerWidth > 600 && <Legend />}  {/* Show legend only on larger screens */}
-              <Line type="monotone" dataKey="SunRun" stroke="#007bff" />
-              <Line type="monotone" dataKey="SCE" stroke="#FF6A00" />
-            </LineChart>
-          </ResponsiveContainer>
+      <div className="calculator-grid">
+        <form className="calculator-form surface-card" onSubmit={handleSubmit}>
+          <div className="form-header">
+            <h3>Usage details</h3>
+            <p>We&rsquo;ll use these figures to determine your current kWh rate.</p>
           </div>
-      </>
-    )}
-    </div>
-  </div>
+
+          <div className="form-group">
+            <label><AttachMoneyIcon /> Monthly Charges</label>
+            <input type="number" step="0.01" value={charges} onChange={(e) => setCharges(e.target.value)} placeholder="e.g. 225.60" required />
+          </div>
+
+          <div className="form-group">
+            <label><PowerOutlinedIcon /> Monthly kWh Usage</label>
+            <input type="number" value={usage} onChange={(e) => setUsage(e.target.value)} placeholder="e.g. 540" required />
+          </div>
+
+          <div className="form-group">
+            <label><BoltTwoToneIcon /> Annual kWh Usage</label>
+            <input type="number" step="0.01" value={annualUsage} onChange={(e) => setAnnualUsage(e.target.value)} placeholder="e.g. 6480" required />
+          </div>
+
+          <div className="form-group">
+            <label><PercentIcon /> Rate change percentage</label>
+            <input type="number" value={scePecentage} onChange={(e) => setScePecentage(e.target.value)} placeholder="Projected annual increase" required />
+          </div>
+
+          <div className="form-group">
+            <label><PercentIcon /> Minimal rate percentage</label>
+            <input type="number" value={projectedFutureRateIncrease} onChange={(e) => setProjectedFutureRateIncrease(e.target.value)} placeholder="Baseline annual increase" required />
+          </div>
+
+          <div className="button-group">
+            <button type="submit">Calculate rate</button>
+            <button className="reset" type="button" onClick={handleReset}>Reset</button>
+          </div>
+        </form>
+
+        <div className="result-panel surface-card">
+          <div className="result-header">
+            <h3>Bill snapshot</h3>
+            <p>See how your current rate compares with upcoming adjustments.</p>
+          </div>
+
+          {rate !== null ? (
+            <>
+              <Box sx={listWrapperStyles}>
+                <List sx={listStyles}>
+                  <ListItem className="result-item">
+                    <ListItemText primary={`The rate is ${rate} per kWh.`} secondary={`($ ${charges || 0} / ${usage || 0})`} />
+                  </ListItem>
+                  <Divider component="li" />
+                  <ListItem className="result-item">
+                    <ListItemText primary={`The average monthly cost is ${avgPerMonthCost}`} secondary={`(${annualUsage || 0} × $ ${rate} / 12)`} />
+                  </ListItem>
+                  <Divider component="li" />
+                  <ListItem className="result-item">
+                    <ListItemText primary={`The monthly bill with change is $ ${projectedMonthlyBill}`} secondary={`(${avgPerMonthCost} × (1 + ${scePecentage || 0} / 100))`} />
+                  </ListItem>
+                </List>
+              </Box>
+
+              <div className="insight-metrics">
+                <div className="metric-card metric-card--primary">
+                  <span className="metric-card__label">Current rate</span>
+                  <strong className="metric-card__value">{formatRate(parsedRate)}</strong>
+                  <span className="metric-card__hint">per kWh today</span>
+                </div>
+
+                <div className="metric-card">
+                  <span className="metric-card__label">Average monthly spend</span>
+                  <strong className="metric-card__value">{formatCurrency(avgMonthlyCostValue, { minimumFractionDigits: 2, maximumFractionDigits: 2 })}</strong>
+                  <span className="metric-card__hint">based on your usage</span>
+                </div>
+
+                <div className="metric-card">
+                  <span className="metric-card__label">Projected monthly bill</span>
+                  <strong className="metric-card__value">{formatCurrency(projectedMonthlyBillValue, { minimumFractionDigits: 2, maximumFractionDigits: 2 })}</strong>
+                  <span className="metric-card__hint">with SCE increases</span>
+                </div>
+
+                {sunrunReady && (
+                  <div className="metric-card metric-card--positive">
+                    <span className="metric-card__label">Year one Sunrun savings</span>
+                    <strong className="metric-card__value">{formatCurrency(firstYearSavings, { minimumFractionDigits: 0, maximumFractionDigits: 0 })}</strong>
+                    <span className="metric-card__hint">vs. projected SCE spend</span>
+                  </div>
+                )}
+              </div>
+
+              <div className="sunrun-input-container">
+                <p className="warning-label">Compare against a Sunrun plan</p>
+                <div className="sunrun-input-row">
+                  <label htmlFor="sunrun-rate"><SolarPowerTwoToneIcon /> Sunrun monthly cost</label>
+                  <input id="sunrun-rate" type="number" step="0.01" value={sunRunAnnualRateIncrease} onChange={(e) => setSunRunAnnualRateIncrease(e.target.value)} placeholder="e.g. 185.00" />
+                </div>
+                <button className="sunrun-calculate-btn" onClick={handleSunRunMonthlyCost} type="button">Update projection</button>
+              </div>
+
+              {sunrunReady && (
+                <div className="insight-panel">
+                  <div className="insight-panel__header">
+                    <h4>Sunrun outlook</h4>
+                    {Number.isFinite(lifetimeSavings) && (
+                      <span className="insight-chip">{formatCurrency(lifetimeSavings)}</span>
+                    )}
+                  </div>
+                  <ul className="insight-panel__list">
+                    <li>
+                      <span>Year one savings potential</span>
+                      <strong>{formatCurrency(firstYearSavings, { minimumFractionDigits: 0, maximumFractionDigits: 0 })}</strong>
+                    </li>
+                    {Number.isFinite(firstYearSceTotal) && (
+                      <li>
+                        <span>Projected SCE year one cost</span>
+                        <strong>{formatCurrency(firstYearSceTotal, { minimumFractionDigits: 0, maximumFractionDigits: 0 })}</strong>
+                      </li>
+                    )}
+                    {Number.isFinite(firstYearSunrunTotal) && (
+                      <li>
+                        <span>Sunrun year one cost</span>
+                        <strong>{formatCurrency(firstYearSunrunTotal, { minimumFractionDigits: 0, maximumFractionDigits: 0 })}</strong>
+                      </li>
+                    )}
+                    <li>
+                      <span>Ten-year savings projection</span>
+                      <strong>{formatCurrency(lifetimeSavings, { minimumFractionDigits: 0, maximumFractionDigits: 0 })}</strong>
+                    </li>
+                    <li>
+                      <span>Share of SCE costs avoided</span>
+                      <strong>{formatPercentage(savingsPercentage)}</strong>
+                    </li>
+                    {bestSavingsYear && (
+                      <li>
+                        <span>Peak annual savings year</span>
+                        <strong>{bestSavingsYear.year}: {formatCurrency(bestSavingsYear.amount, { minimumFractionDigits: 0, maximumFractionDigits: 0 })}</strong>
+                      </li>
+                    )}
+                  </ul>
+                  <p className="insight-panel__footnote">Savings assume Sunrun bills escalate at 3.5% annually compared with your projected SCE increases.</p>
+                </div>
+              )}
+            </>
+          ) : (
+            <div className="empty-state">
+              <h4>Ready when you are</h4>
+              <p>Provide your charges and usage to unlock projections tailored to your household.</p>
+            </div>
+          )}
+        </div>
+      </div>
+
+      {rate !== null && chartData.length > 0 && (
+        <div className="chart-card surface-card">
+          <div className="chart-header">
+            <h3>Projected monthly bills (next 10 years)</h3>
+            <p>Track the gap between SCE&rsquo;s expected increases and Sunrun&rsquo;s steady 3.5% escalation.</p>
+          </div>
+
+          <div className="chart-wrapper">
+            <ResponsiveContainer width="100%" height={420}>
+              <ComposedChart data={chartData} margin={{ top: 20, right: 20, bottom: 20, left: 0 }}>
+                <defs>
+                  <linearGradient id="savingsGradient" x1="0" y1="0" x2="0" y2="1">
+                    <stop offset="5%" stopColor="#22c55e" stopOpacity={0.35} />
+                    <stop offset="95%" stopColor="#22c55e" stopOpacity={0.05} />
+                  </linearGradient>
+                </defs>
+                <CartesianGrid strokeDasharray="4 4" stroke="#cbd5f5" vertical={false} strokeOpacity={0.6} />
+                <XAxis dataKey="year" tick={{ fontSize: 12, fill: '#334155' }} angle={-30} textAnchor="end" interval={0} height={70} tickLine={false} axisLine={{ stroke: 'rgba(148, 163, 184, 0.4)' }} />
+                <YAxis tickFormatter={currencyFormatter} tick={{ fontSize: 12, fill: '#334155' }} width={90} tickLine={false} axisLine={false} />
+                <Tooltip content={<ChartTooltip />} cursor={{ strokeDasharray: '4 2', stroke: '#94a3b8' }} />
+                {isDesktop && (
+                  <Legend
+                    verticalAlign="top"
+                    align="right"
+                    wrapperStyle={{ paddingBottom: 20, paddingRight: 14 }}
+                    iconType="circle"
+                    iconSize={12}
+                  />
+                )}
+                <Area type="monotone" dataKey="Savings" stroke="none" fill="url(#savingsGradient)" fillOpacity={1} legendType="none" />
+                <Line
+                  type="monotone"
+                  dataKey="SunRun"
+                  stroke="#2563eb"
+                  strokeWidth={3}
+                  dot={{ r: 4, strokeWidth: 2, stroke: '#f8fafc' }}
+                  activeDot={{ r: 7, strokeWidth: 2, stroke: '#0f172a' }}
+                />
+                <Line
+                  type="monotone"
+                  dataKey="SCE"
+                  stroke="#f97316"
+                  strokeWidth={3}
+                  strokeDasharray="6 3"
+                  dot={{ r: 4, strokeWidth: 2, stroke: '#f8fafc' }}
+                  activeDot={{ r: 7, strokeWidth: 2, stroke: '#0f172a' }}
+                />
+              </ComposedChart>
+            </ResponsiveContainer>
+          </div>
+        </div>
+      )}
+    </section>
   )
 }
 

--- a/src/Components/Calculator/styles.css
+++ b/src/Components/Calculator/styles.css
@@ -1,84 +1,96 @@
-/* Global Styles */
-* {
-  margin: 0;
-  padding: 0;
-  box-sizing: border-box;
+:root {
+  font-family: 'Inter', 'Segoe UI', 'Helvetica Neue', Arial, sans-serif;
+  color-scheme: light;
 }
 
 body {
-  font-family: 'Arial', sans-serif;
-  background: linear-gradient(to bottom, #F0F8FF, #FFF8E1); /* Soft blue to warm yellow */
-  color: #333; /* Dark text for readability */
-  font-family: 'Arial', sans-serif;
   margin: 0;
-  padding: 0;
+  font-family: 'Inter', 'Segoe UI', 'Helvetica Neue', Arial, sans-serif;
+  color: #0f172a;
 }
 
-/* Main Container */
 .calculator-container {
   display: flex;
   flex-direction: column;
-  justify-content: flex-start;
-  padding: 30px;
-  margin: 0 auto;
-  background-color: #fff;
-  border-radius: 10px;
-  max-width: 900px;
+  gap: 32px;
   width: 100%;
+  max-width: 1100px;
+  margin: 0 auto;
+  color: #0f172a;
 }
 
 .calculator-header {
   text-align: center;
-  margin-bottom: 20px;
-}
-
-h2 {
-  font-size: 26px;
-  color: #333;
-  margin-bottom: 15px;
-}
-
-button {
-  padding: 12px 20px;
-  background-color: #007bff;
-  color: white;
-  border: none;
-  border-radius: 4px;
-  cursor: pointer;
-  font-size: 16px;
-  transition: background-color 0.3s ease;
-  width: 100%;
-}
-
-button:hover {
-  background-color: #0056b3;
-}
-
-button.reset {
-  background-color: #dc3545;
-}
-
-button.reset:hover {
-  background-color: #c82333;
-}
-
-button.sunrun-calculate-btn {
-  background-color: #28a745;
-  margin-top: 10px;
-  max-width: 600px;
-  width: 47%;
-}
-
-button.sunrun-calculate-btn:hover {
-  background-color: #218838;
-}
-
-/* Form Layout */
-.calculator-form {
   display: flex;
   flex-direction: column;
-  gap: 20px;
-  margin-bottom: 20px;
+  gap: 12px;
+}
+
+.calculator-badge {
+  align-self: center;
+  background: rgba(37, 99, 235, 0.12);
+  color: #1d4ed8;
+  font-weight: 600;
+  font-size: 0.85rem;
+  padding: 6px 14px;
+  border-radius: 999px;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+}
+
+.calculator-header h1 {
+  font-size: clamp(2rem, 2.8vw, 2.75rem);
+  font-weight: 700;
+  margin: 0;
+}
+
+.calculator-header p {
+  max-width: 640px;
+  margin: 0 auto;
+  color: #475569;
+  font-size: 1rem;
+  line-height: 1.6;
+}
+
+.calculator-grid {
+  display: grid;
+  gap: 24px;
+  grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
+}
+
+.surface-card {
+  position: relative;
+  background: rgba(255, 255, 255, 0.92);
+  border-radius: 24px;
+  padding: clamp(24px, 2.8vw, 32px);
+  border: 1px solid rgba(148, 163, 184, 0.25);
+  box-shadow: 0 25px 55px rgba(15, 23, 42, 0.12);
+  backdrop-filter: blur(16px);
+  overflow: hidden;
+}
+
+.surface-card::before {
+  content: '';
+  position: absolute;
+  inset: 0;
+  background: radial-gradient(circle at top right, rgba(59, 130, 246, 0.12), transparent 55%);
+  opacity: 0.7;
+  pointer-events: none;
+}
+
+.form-header {
+  margin-bottom: 18px;
+}
+
+.form-header h3 {
+  margin: 0 0 6px;
+  font-size: 1.4rem;
+}
+
+.form-header p {
+  margin: 0;
+  color: #64748b;
+  font-size: 0.95rem;
 }
 
 .form-group {
@@ -87,115 +99,475 @@ button.sunrun-calculate-btn:hover {
   gap: 8px;
 }
 
+.form-group + .form-group {
+  margin-top: 16px;
+}
+
 .form-group label {
-  font-size: 16px;
-  color: #333;
+  font-weight: 600;
+  color: #0f172a;
+  display: flex;
+  align-items: center;
+  gap: 8px;
 }
 
 .form-group input {
-  padding: 12px;
-  font-size: 16px;
-  border: 1px solid #ddd;
-  border-radius: 4px;
-  width: 100%;
-  max-width: 400px;
-  transition: border-color 0.3s ease;
+  padding: 14px 16px;
+  font-size: 1rem;
+  border-radius: 16px;
+  border: 1px solid rgba(148, 163, 184, 0.4);
+  transition: border-color 0.3s ease, box-shadow 0.3s ease;
+  background: rgba(248, 250, 252, 0.9);
 }
 
 .form-group input:focus {
   outline: none;
-  border-color: #007bff;
+  border-color: #2563eb;
+  box-shadow: 0 0 0 4px rgba(37, 99, 235, 0.15);
 }
 
 .button-group {
   display: flex;
-  gap: 12px;
   flex-wrap: wrap;
+  gap: 12px;
+  margin-top: 24px;
+}
+
+button {
+  border: none;
+  border-radius: 999px;
+  padding: 13px 22px;
+  font-weight: 600;
+  font-size: 1rem;
+  cursor: pointer;
+  transition: transform 0.2s ease, box-shadow 0.2s ease, background 0.2s ease;
 }
 
 .button-group button {
-  width: 48%;
-  max-width: 250px;
+  flex: 1 1 180px;
+  background: linear-gradient(135deg, #2563eb, #1d4ed8);
+  color: #fff;
+  box-shadow: 0 15px 30px rgba(37, 99, 235, 0.25);
+}
+
+.button-group button:hover {
+  transform: translateY(-2px);
+  box-shadow: 0 18px 38px rgba(37, 99, 235, 0.28);
+}
+
+.button-group .reset {
+  background: rgba(15, 23, 42, 0.08);
+  color: #0f172a;
+  box-shadow: none;
+}
+
+.button-group .reset:hover {
+  background: rgba(15, 23, 42, 0.12);
+  box-shadow: none;
+}
+
+.result-panel {
+  display: flex;
+  flex-direction: column;
+  gap: 20px;
+}
+
+.insight-metrics {
+  display: grid;
+  gap: 16px;
+  margin-top: 18px;
+  grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+}
+
+.metric-card {
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  padding: 18px 20px;
+  border-radius: 18px;
+  background: rgba(248, 250, 252, 0.88);
+  border: 1px solid rgba(148, 163, 184, 0.35);
+  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.25);
+  transition: transform 0.25s ease, box-shadow 0.25s ease;
+}
+
+.metric-card::after {
+  content: '';
+  position: absolute;
+  inset: 0;
+  border-radius: inherit;
+  background: linear-gradient(135deg, rgba(37, 99, 235, 0.08), rgba(59, 130, 246, 0));
+  opacity: 0;
+  transition: opacity 0.3s ease;
+  pointer-events: none;
+}
+
+.metric-card:hover {
+  transform: translateY(-4px);
+  box-shadow: 0 18px 35px rgba(15, 23, 42, 0.18);
+}
+
+.metric-card:hover::after {
+  opacity: 1;
+}
+
+.metric-card__label {
+  font-size: 0.75rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: #475569;
+  font-weight: 600;
+}
+
+.metric-card__value {
+  font-size: clamp(1.35rem, 2.4vw, 1.6rem);
+  font-weight: 700;
+  color: #0f172a;
+}
+
+.metric-card__hint {
+  font-size: 0.85rem;
+  color: #64748b;
+}
+
+.metric-card--primary {
+  background: linear-gradient(135deg, rgba(37, 99, 235, 0.16), rgba(59, 130, 246, 0.08));
+  border-color: rgba(59, 130, 246, 0.35);
+}
+
+.metric-card--primary .metric-card__label {
+  color: #1d4ed8;
+}
+
+.metric-card--positive {
+  background: linear-gradient(135deg, rgba(34, 197, 94, 0.18), rgba(16, 185, 129, 0.12));
+  border-color: rgba(16, 185, 129, 0.35);
+}
+
+.metric-card--positive .metric-card__label {
+  color: #15803d;
+}
+
+.result-header h3 {
+  margin: 0 0 6px;
+  font-size: 1.35rem;
+}
+
+.result-header p {
+  margin: 0;
+  color: #64748b;
+}
+
+.result-item .MuiListItemText-primary {
+  font-weight: 600;
+  color: #0f172a;
+  font-size: 1.05rem;
+}
+
+.result-item .MuiListItemText-secondary {
+  margin-top: 4px;
+  color: #64748b;
+  font-size: 0.9rem;
 }
 
 .sunrun-input-container {
-  text-align: center;
-  margin-top: 30px;
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+  padding: 18px 20px;
+  border-radius: 18px;
+  background: linear-gradient(135deg, rgba(199, 210, 254, 0.35), rgba(191, 219, 254, 0.35));
+  border: 1px solid rgba(148, 163, 184, 0.2);
 }
 
-.sunrun-input-container input {
-  padding: 12px;
+.insight-panel {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+  padding: 20px 22px;
+  border-radius: 20px;
+  border: 1px solid rgba(148, 163, 184, 0.28);
+  background: linear-gradient(140deg, rgba(15, 118, 110, 0.08), rgba(34, 197, 94, 0.12));
+  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.18);
+}
+
+.insight-panel__header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+}
+
+.insight-panel__header h4 {
+  margin: 0;
+  font-size: 1.1rem;
+  font-weight: 700;
+}
+
+.insight-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 6px 12px;
+  border-radius: 999px;
+  background: rgba(22, 163, 74, 0.16);
+  color: #15803d;
+  font-weight: 600;
+  font-size: 0.85rem;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+}
+
+.insight-panel__list {
+  list-style: none;
+  display: grid;
+  gap: 12px;
+  margin: 0;
+  padding: 0;
+}
+
+.insight-panel__list li {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 14px;
+  font-size: 0.95rem;
+  color: #0f172a;
+}
+
+.insight-panel__list span {
+  color: #0f172a;
+  font-weight: 500;
+}
+
+.insight-panel__list strong {
+  font-weight: 700;
+  font-size: 1rem;
+  color: #047857;
+}
+
+.insight-panel__footnote {
+  margin: 0;
+  font-size: 0.8rem;
+  color: #0f766e;
+  line-height: 1.5;
+}
+
+.sunrun-input-row {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  align-items: flex-start;
+}
+
+.sunrun-input-row label {
+  font-weight: 600;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.sunrun-input-row input {
   width: 100%;
-  max-width: 400px;
-  font-size: 16px;
+  max-width: 240px;
+  padding: 12px 14px;
+  border-radius: 14px;
+  border: 1px solid rgba(148, 163, 184, 0.35);
+  background: rgba(255, 255, 255, 0.9);
+}
+
+.sunrun-input-row input:focus {
+  outline: none;
+  border-color: #22c55e;
+  box-shadow: 0 0 0 4px rgba(34, 197, 94, 0.15);
+}
+
+.sunrun-calculate-btn {
+  align-self: flex-start;
+  background: linear-gradient(135deg, #22c55e, #16a34a);
+  color: #fff;
+  box-shadow: 0 12px 24px rgba(34, 197, 94, 0.28);
+}
+
+.sunrun-calculate-btn:hover {
+  transform: translateY(-2px);
+  box-shadow: 0 16px 32px rgba(34, 197, 94, 0.32);
 }
 
 .warning-label {
-  font-weight: bold;
-  margin-bottom: 10px;
+  font-size: 0.95rem;
+  font-weight: 600;
+  color: #166534;
 }
 
-.result-container {
-  margin-top: 30px;
+.empty-state {
+  padding: 26px;
+  border-radius: 18px;
+  background: rgba(248, 250, 252, 0.75);
+  border: 1px dashed rgba(148, 163, 184, 0.35);
+  text-align: center;
 }
 
-.mobile-graph-layout {
-  margin-top: 20px;
+.empty-state h4 {
+  margin: 0 0 10px;
+  font-size: 1.25rem;
+}
+
+.empty-state p {
+  margin: 0;
+  color: #64748b;
+}
+
+.chart-card {
+  display: flex;
+  flex-direction: column;
+  gap: 20px;
+  background: radial-gradient(circle at top right, rgba(59, 130, 246, 0.08), transparent 55%);
+  position: relative;
+  overflow: hidden;
+}
+
+.chart-card::before {
+  content: '';
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(160deg, rgba(37, 99, 235, 0.08), rgba(14, 165, 233, 0.04));
+  opacity: 0.6;
+  pointer-events: none;
+}
+
+.chart-header h3 {
+  margin: 0;
+  font-size: 1.4rem;
+}
+
+.chart-header p {
+  margin: 6px 0 0;
+  color: #64748b;
+}
+
+.chart-wrapper {
   width: 100%;
+  height: 100%;
+  padding: 8px 0 4px;
+  position: relative;
 }
 
-/* Result List Styling */
-.list-item-text {
-  font-size: 16px;
-  color: #333;
+.chart-wrapper::after {
+  content: '';
+  position: absolute;
+  inset: 16px;
+  border-radius: 24px;
+  border: 1px solid rgba(148, 163, 184, 0.22);
+  pointer-events: none;
 }
 
-/* Mobile-specific styles */
-@media (max-width: 600px) {
-  .mobile-graph-layout {
-    width: 100%;  /* Ensure it takes full width */
-    margin-top: 20px;  /* Optional: Add some margin for better spacing */
-  }
+.chart-tooltip {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  min-width: 200px;
+  padding: 14px 16px;
+  border-radius: 16px;
+  background: rgba(15, 23, 42, 0.9);
+  color: #f8fafc;
+  box-shadow: 0 18px 45px rgba(15, 23, 42, 0.25);
 }
 
-/* Responsive Layout */
-@media (min-width: 600px) {
+.chart-tooltip__label {
+  margin: 0;
+  font-size: 0.9rem;
+  letter-spacing: 0.03em;
+  text-transform: uppercase;
+  color: rgba(226, 232, 240, 0.85);
+}
+
+.chart-tooltip__item {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  font-size: 0.95rem;
+  position: relative;
+  padding-left: 18px;
+  gap: 16px;
+}
+
+.chart-tooltip__item::before {
+  content: '';
+  position: absolute;
+  left: 0;
+  top: 50%;
+  transform: translateY(-50%);
+  width: 10px;
+  height: 10px;
+  border-radius: 999px;
+  background: var(--color, #2563eb);
+  box-shadow: 0 0 0 3px rgba(148, 163, 184, 0.25);
+}
+
+.chart-tooltip__item strong {
+  font-size: 1rem;
+  letter-spacing: 0.02em;
+}
+
+.chart-tooltip__savings {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-top: 8px;
+  padding: 10px 12px;
+  border-radius: 14px;
+  background: rgba(34, 197, 94, 0.12);
+  color: #4ade80;
+  font-weight: 600;
+  font-size: 0.95rem;
+}
+
+.recharts-default-legend {
+  padding-right: 14px !important;
+}
+
+.recharts-legend-item-text {
+  color: #0f172a !important;
+  font-weight: 600;
+  letter-spacing: 0.01em;
+}
+
+@media (max-width: 768px) {
   .calculator-container {
-    padding: 40px;
+    padding: 0 4px;
   }
 
-  .form-group input,
-  .button-group button {
-    width: 48%;
-    max-width: 300px;
+  .surface-card {
+    border-radius: 20px;
+    padding: 22px;
   }
 
-  .result-container {
-    width: 100%;
+  .insight-metrics {
+    grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
+    margin-top: 16px;
   }
 
   .button-group {
-    justify-content: space-between;
+    flex-direction: column;
+  }
+
+  .button-group button {
+    width: 100%;
+  }
+
+  .sunrun-input-row input {
+    max-width: 100%;
+  }
+
+  .chart-wrapper::after {
+    inset: 12px;
   }
 }
 
-@media (min-width: 900px) {
+@media (min-width: 1100px) {
   .calculator-container {
-    max-width: 900px;
-    margin: 40px auto;
-  }
-
-  .form-group input,
-  .button-group button {
-    width: 48%;
-  }
-
-  .result-container {
-    margin-top: 50px;
-  }
-
-  .mobile-graph-layout {
-    width: 100%;
-    margin-top: 30px;
+    padding: 0 10px;
   }
 }


### PR DESCRIPTION
## Summary
- add floating ambient glows to the app shell to create a richer backdrop for the calculator
- surface new formatted insight metrics, Sunrun outlook details, and chart tweaks for clearer projections
- refresh calculator styling with glassy cards, gradient chips, and framed chart wrapper accents

## Testing
- npm test -- --watchAll=false

------
https://chatgpt.com/codex/tasks/task_e_68d8556b0bcc8327ae6fa65712e82eab