### PR TITLE
Remove presets and add percentage-based insights

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -9,6 +9,7 @@ body {
   min-height: 100vh;
   position: relative;
   overflow-x: hidden;
+  background-attachment: fixed;
 }
 
 body::before,
@@ -49,4 +50,16 @@ body::after {
   border-radius: 48px;
   filter: blur(12px);
   z-index: -1;
+}
+
+.app-shell::after {
+  content: '';
+  position: absolute;
+  inset: 8% 10%;
+  background-image: radial-gradient(rgba(148, 163, 184, 0.18) 1px, transparent 0);
+  background-size: 32px 32px;
+  opacity: 0.45;
+  z-index: -2;
+  mask: linear-gradient(180deg, rgba(255, 255, 255, 0.85), transparent 80%);
+  -webkit-mask: linear-gradient(180deg, rgba(255, 255, 255, 0.85), transparent 80%);
 }

--- a/src/Components/Calculator/calculator.js
+++ b/src/Components/Calculator/calculator.js
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from 'react'
+import React, { useState, useEffect, useCallback } from 'react'
 import { ComposedChart, Line, Area, XAxis, YAxis, CartesianGrid, Tooltip, Legend, ResponsiveContainer } from 'recharts'
 import AttachMoneyIcon from '@mui/icons-material/AttachMoney'
 import BoltTwoToneIcon from '@mui/icons-material/BoltTwoTone'
@@ -10,9 +10,13 @@ import ListItemText from '@mui/material/ListItemText'
 import PowerOutlinedIcon from '@mui/icons-material/PowerOutlined'
 import Box from '@mui/material/Box'
 import PercentIcon from '@mui/icons-material/Percent'
+import TrendingUpIcon from '@mui/icons-material/TrendingUp'
+import InsightsIcon from '@mui/icons-material/Insights'
+import EventAvailableIcon from '@mui/icons-material/EventAvailable'
 import './styles.css'  // Importing the updated CSS file
 
 const xYearsLabel = ["2025", "2026", "2027", "2028", "2029", "2030", "2031", "2032", "2033", "2034", "2035"]
+const SUNRUN_ESCALATION = 3.5
 
 const listStyles = {
   py: 0,
@@ -75,7 +79,7 @@ const Calculator = () => {
   const [annualUsage, setAnnualUsage] = useState('')
   const [scePecentage, setScePecentage] = useState('')
   const [projectedMonthlyBill, setProjectedMonthlyBill] = useState(null)
-  const [sunRunAnnualRateIncrease, setSunRunAnnualRateIncrease] = useState('0.00')
+  const [sunRunMonthlyCost, setSunRunMonthlyCost] = useState('')
   const [rate, setRate] = useState(null)
   const [projectedFutureRateIncrease, setProjectedFutureRateIncrease] = useState('0.00')
   const [avgPerMonthCost, setAvgPerMonthCost] = useState(null)
@@ -95,7 +99,7 @@ const Calculator = () => {
   function calculateRate() {
     const chargesValue = parseFloat(charges)
     const usageValues = parseFloat(usage)
-  
+
     if (chargesValue > 0 && usageValues > 0) {
       const calculatedRate = chargesValue / usageValues
       const roundedRate = Math.floor(calculatedRate * 100) / 100
@@ -105,21 +109,8 @@ const Calculator = () => {
     }
   }
 
-  function calculateAnnualUsage() {
-    const parsedPercentage = parseFloat(scePecentage)
-
-    if (rate && annualUsage > 0 && !Number.isNaN(parsedPercentage)) {
-      const avgMonthlyBill = (annualUsage * parseFloat(rate)) / 12
-      const projectedFutureAvg = avgMonthlyBill * (parsedPercentage / 100)
-      const totalProjectedMontlyBill = avgMonthlyBill + projectedFutureAvg
-
-      setAvgPerMonthCost(avgMonthlyBill.toFixed(2))
-      setProjectedMonthlyBill(totalProjectedMontlyBill.toFixed(2))
-    }
-  }
-
-  function generateProjectedBills(initialBill, sunRunStartMonthlyCost) {
-    const sunrunIncrease = 1.035 // 3.5% annual increase
+  const generateProjectedBills = useCallback((initialBill, sunRunStartMonthlyCost) => {
+    const sunrunIncrease = 1 + SUNRUN_ESCALATION / 100
     const parsedInitialIncrease = parseFloat(scePecentage)
     const parsedMinIncrease = parseFloat(projectedFutureRateIncrease)
     const sceInitialIncrease = 1 + (Number.isNaN(parsedInitialIncrease) ? 0 : parsedInitialIncrease) / 100
@@ -149,19 +140,39 @@ const Calculator = () => {
     }
 
     setProjectedBills({ sunrunBills, sceBills })
-  }
+  }, [scePecentage, projectedFutureRateIncrease])
 
   useEffect(() => {
-    if (rate && annualUsage > 0) {
-      calculateAnnualUsage() // Only calculate annual usage if conditions are met
+    const parsedPercentage = parseFloat(scePecentage)
+    const parsedRate = rate !== null ? parseFloat(rate) : null
+
+    if (parsedRate && annualUsage > 0 && !Number.isNaN(parsedPercentage)) {
+      const avgMonthlyBill = (annualUsage * parsedRate) / 12
+      const projectedFutureAvg = avgMonthlyBill * (parsedPercentage / 100)
+      const totalProjectedMontlyBill = avgMonthlyBill + projectedFutureAvg
+
+      setAvgPerMonthCost(avgMonthlyBill.toFixed(2))
+      setProjectedMonthlyBill(totalProjectedMontlyBill.toFixed(2))
+    } else {
+      setAvgPerMonthCost(null)
+      setProjectedMonthlyBill(null)
     }
-  }, [rate, annualUsage]); // Remove calculateAnnualUsage and avgPerMonthCost from the dependencies
+  }, [rate, annualUsage, scePecentage])
 
   useEffect(() => {
-    if (avgPerMonthCost) {
-      generateProjectedBills(parseFloat(avgPerMonthCost), parseFloat(sunRunAnnualRateIncrease)); // Now, handle projected bills based on avgPerMonthCost in a separate effect
+    if (!avgPerMonthCost) {
+      return
     }
-  }, [avgPerMonthCost]);
+
+    const parsedSunrun = parseFloat(sunRunMonthlyCost)
+
+    if (!Number.isFinite(parsedSunrun) || parsedSunrun <= 0) {
+      setProjectedBills({ sunrunBills: [], sceBills: [] })
+      return
+    }
+
+    generateProjectedBills(parseFloat(avgPerMonthCost), parsedSunrun)
+  }, [avgPerMonthCost, sunRunMonthlyCost, generateProjectedBills])
 
   useEffect(() => {
     if (typeof window === 'undefined') {
@@ -183,10 +194,11 @@ const Calculator = () => {
   }
 
   const handleSunRunMonthlyCost = (e) => {
-    if (rate && sunRunAnnualRateIncrease > 0) {
+    const parsedSunrun = parseFloat(sunRunMonthlyCost)
+
+    if (rate && avgPerMonthCost && Number.isFinite(parsedSunrun) && parsedSunrun > 0) {
       // Trigger the projected bills calculation with the SunRun start rate
-      const sunRunStartMonthlyCost = parseFloat(sunRunAnnualRateIncrease)
-      generateProjectedBills(parseFloat(avgPerMonthCost), sunRunStartMonthlyCost)
+      generateProjectedBills(parseFloat(avgPerMonthCost), parsedSunrun)
     } else {
       console.error("Rate or SunRun Start Monthly Cost is not set properly.")
     }
@@ -197,7 +209,7 @@ const Calculator = () => {
     setUsage('')
     setAnnualUsage('')
     setScePecentage('')
-    setSunRunAnnualRateIncrease('0.00')
+    setSunRunMonthlyCost('')
     setRate(null)
     setProjectedFutureRateIncrease('0.00')
     setAvgPerMonthCost(null)
@@ -227,16 +239,44 @@ const Calculator = () => {
     .filter(Boolean)
 
   const projectedMonthlyBillNumber = rate !== null && projectedMonthlyBill ? parseFloat(projectedMonthlyBill) : null
-  const sunrunMonthlyCostNumber = sunRunAnnualRateIncrease ? parseFloat(sunRunAnnualRateIncrease) : null
+  const sunrunMonthlyCostNumber = sunRunMonthlyCost ? parseFloat(sunRunMonthlyCost) : null
   const monthlySavings = projectedMonthlyBillNumber !== null && sunrunMonthlyCostNumber > 0
     ? projectedMonthlyBillNumber - sunrunMonthlyCostNumber
     : null
   const firstYearSavings = chartData.length > 0 ? chartData[0].Savings * 12 : null
   const tenYearSavings = chartData.length > 0 ? chartData[chartData.length - 1].Savings * 12 : null
+  const fiveYearSavings = chartData.length > 0 ? chartData.slice(0, 5).reduce((acc, item) => acc + item.Savings * 12, 0) : null
+  const cumulativeTenYearSavings = chartData.length > 0 ? chartData.reduce((acc, item) => acc + item.Savings * 12, 0) : null
+  const peakSavings = chartData.reduce((best, item) => {
+    if (!best || item.Savings > best.Savings) {
+      return { year: item.year, Savings: item.Savings }
+    }
+
+    return best
+  }, null)
   const monthlyDifferenceDisplay = monthlySavings !== null ? Math.abs(monthlySavings) : null
   const monthlyDifferenceLabel = monthlySavings !== null && monthlySavings < 0 ? 'added cost' : 'saved'
   const hasFirstYearSavings = firstYearSavings !== null && firstYearSavings > 0
   const hasTenYearSavings = tenYearSavings !== null && tenYearSavings > 0
+  const hasFiveYearSavings = fiveYearSavings !== null && fiveYearSavings > 0
+  const hasCumulativeTenYearSavings = cumulativeTenYearSavings !== null && cumulativeTenYearSavings > 0
+  const hasPeakSavings = peakSavings !== null && peakSavings.Savings > 0
+
+  const parsedProjectedIncrease = parseFloat(scePecentage)
+  const parsedBaselineIncrease = parseFloat(projectedFutureRateIncrease)
+  const hasProjectedIncrease = !Number.isNaN(parsedProjectedIncrease)
+  const hasBaselineIncrease = !Number.isNaN(parsedBaselineIncrease)
+  const projectedVsBaselineDiff = hasProjectedIncrease && hasBaselineIncrease
+    ? parsedProjectedIncrease - parsedBaselineIncrease
+    : null
+  const projectedVsSunrunDiff = hasProjectedIncrease ? parsedProjectedIncrease - SUNRUN_ESCALATION : null
+  const formatPercentage = (value) => {
+    if (value === null || Number.isNaN(value)) {
+      return '--'
+    }
+
+    return `${value.toFixed(1)}%`
+  }
 
   const formatCurrency = (value, options = {}) => {
     if (value === null || Number.isNaN(value)) {
@@ -251,7 +291,7 @@ const Calculator = () => {
       <div className="calculator-header">
         <span className="calculator-badge">Energy insights</span>
         <h1><span>Visualize</span> your SCE costs with clarity</h1>
-        <p>Enter your recent charges and usage to calculate today&rsquo;s rate, then explore how future increases compare with a predictable Sunrun plan.</p>
+        <p>Enter your recent charges and usage to calculate today&rsquo;s rate, then explore how your percentage-based projections stack up against a steady Sunrun plan.</p>
         <div className="header-pills">
           <span>10-year projection</span>
           <span>Side-by-side comparison</span>
@@ -283,12 +323,28 @@ const Calculator = () => {
 
           <div className="form-group">
             <label><PercentIcon /> Rate change percentage</label>
-            <input type="number" value={scePecentage} onChange={(e) => setScePecentage(e.target.value)} placeholder="Projected annual increase" required />
+            <input
+              type="number"
+              value={scePecentage}
+              onChange={(e) => {
+                setScePecentage(e.target.value)
+              }}
+              placeholder="Projected annual increase"
+              required
+            />
           </div>
 
           <div className="form-group">
             <label><PercentIcon /> Minimal rate percentage</label>
-            <input type="number" value={projectedFutureRateIncrease} onChange={(e) => setProjectedFutureRateIncrease(e.target.value)} placeholder="Baseline annual increase" required />
+            <input
+              type="number"
+              value={projectedFutureRateIncrease}
+              onChange={(e) => {
+                setProjectedFutureRateIncrease(e.target.value)
+              }}
+              placeholder="Baseline annual increase"
+              required
+            />
           </div>
 
           <div className="button-group">
@@ -325,7 +381,7 @@ const Calculator = () => {
                 <p className="warning-label">Compare against a Sunrun plan</p>
                 <div className="sunrun-input-row">
                   <label htmlFor="sunrun-rate"><SolarPowerTwoToneIcon /> Sunrun monthly cost</label>
-                  <input id="sunrun-rate" type="number" step="0.01" value={sunRunAnnualRateIncrease} onChange={(e) => setSunRunAnnualRateIncrease(e.target.value)} placeholder="e.g. 185.00" />
+                  <input id="sunrun-rate" type="number" step="0.01" value={sunRunMonthlyCost} onChange={(e) => setSunRunMonthlyCost(e.target.value)} placeholder="e.g. 185.00" />
                 </div>
                 <button className="sunrun-calculate-btn" onClick={handleSunRunMonthlyCost} type="button">Update projection</button>
               </div>
@@ -334,7 +390,7 @@ const Calculator = () => {
                 <article className="insight-card accent-blue">
                   <span className="insight-label">Current rate</span>
                   <span className="insight-metric">${rate} <span className="insight-unit">/ kWh</span></span>
-                  <p className="insight-caption">Reflects today&rsquo;s billing with a {scePecentage || 0}% annual increase assumption.</p>
+                  <p className="insight-caption">Reflects today&rsquo;s billing with your projected {scePecentage || 0}% annual increase.</p>
                 </article>
 
                 <article className="insight-card accent-emerald">
@@ -345,7 +401,7 @@ const Calculator = () => {
                   </span>
                   <p className="insight-caption">
                     {hasFirstYearSavings
-                      ? `Keep roughly $${formatCurrency(firstYearSavings)} more in year one when compared with Sunrun.`
+                      ? `Keep roughly $${formatCurrency(firstYearSavings)} more in year one when compared with Sunrun’s ${SUNRUN_ESCALATION.toFixed(1)}% escalation.`
                       : monthlySavings !== null && monthlySavings < 0
                         ? 'Sunrun currently adds to your monthly costs—lower the starting rate to see savings.'
                         : 'Enter a Sunrun monthly cost to explore first-year savings.'}
@@ -360,13 +416,106 @@ const Calculator = () => {
                   </span>
                   <p className="insight-caption">
                     {hasTenYearSavings
-                      ? `Projected annual savings by ${chartData.length > 0 ? chartData[chartData.length - 1].year : '2035'} assuming current trends continue.`
+                      ? `Projected annual savings by ${chartData.length > 0 ? chartData[chartData.length - 1].year : '2035'} using your utility increase inputs.`
                       : monthlySavings !== null && monthlySavings < 0
                         ? 'Sunrun remains above SCE over the next decade at this rate.'
                         : 'Add a Sunrun monthly cost to unlock decade-long comparisons.'}
                   </p>
                 </article>
+                <article className="insight-card accent-violet">
+                  <span className="insight-label">Five-year cushion</span>
+                  <span className="insight-metric">
+                    {hasFiveYearSavings ? `$${formatCurrency(fiveYearSavings)}` : '--'}
+                    {hasFiveYearSavings && <span className="insight-unit"> cumulative</span>}
+                  </span>
+                  <p className="insight-caption">
+                    {hasFiveYearSavings
+                      ? `Keep roughly $${formatCurrency(fiveYearSavings, { minimumFractionDigits: 0 })} in your pocket during the first five years.`
+                      : 'If this value reads zero, lower the Sunrun starting cost or adjust rate increases to uncover savings.'}
+                  </p>
+                </article>
               </div>
+
+              <div className="assumption-panel">
+                <div className="assumption-panel__header">
+                  <h4>Annual increase inputs</h4>
+                  <p>Compare the percentages you entered for utility growth with Sunrun&rsquo;s assumed escalation.</p>
+                </div>
+                <div className="assumption-panel__grid">
+                  <div className="assumption-metric">
+                    <span className="assumption-metric__label">Projected SCE increase</span>
+                    <span className="assumption-metric__value">{hasProjectedIncrease ? formatPercentage(parsedProjectedIncrease) : '--'}</span>
+                  </div>
+                  <div className="assumption-metric">
+                    <span className="assumption-metric__label">Baseline SCE increase</span>
+                    <span className="assumption-metric__value">{hasBaselineIncrease ? formatPercentage(parsedBaselineIncrease) : '--'}</span>
+                  </div>
+                  <div className="assumption-metric">
+                    <span className="assumption-metric__label">Sunrun escalation</span>
+                    <span className="assumption-metric__value">{formatPercentage(SUNRUN_ESCALATION)}</span>
+                  </div>
+                  <div className="assumption-metric">
+                    <span className="assumption-metric__label">Projected vs. baseline</span>
+                    <span className="assumption-metric__value">{projectedVsBaselineDiff !== null ? formatPercentage(projectedVsBaselineDiff) : '--'}</span>
+                  </div>
+                  <div className="assumption-metric">
+                    <span className="assumption-metric__label">Projected vs. Sunrun</span>
+                    <span className="assumption-metric__value">{projectedVsSunrunDiff !== null ? formatPercentage(projectedVsSunrunDiff) : '--'}</span>
+                  </div>
+                </div>
+                <p className="assumption-panel__caption">
+                  {hasProjectedIncrease
+                    ? `Your projected SCE increase is ${formatPercentage(parsedProjectedIncrease)} compared with a ${formatPercentage(SUNRUN_ESCALATION)} Sunrun escalation.`
+                    : 'Provide projected and baseline percentages to compare assumptions.'}
+                </p>
+              </div>
+
+              {(hasCumulativeTenYearSavings || hasPeakSavings) && (
+                <div className="savings-summary">
+                  <div className="savings-summary__header">
+                    <span className="savings-summary__badge"><TrendingUpIcon /> Savings storyline</span>
+                    <h4>See how the gap evolves as rates shift</h4>
+                    <p>Your figures recalculate instantly as you tweak the plan above.</p>
+                  </div>
+                  <div className="savings-summary__grid">
+                    <div className="metric-chip">
+                      <span className="metric-chip__icon" aria-hidden="true">
+                        <EventAvailableIcon />
+                      </span>
+                      <div>
+                        <p className="metric-chip__label">Ten-year cumulative</p>
+                        <p className="metric-chip__value">
+                          {hasCumulativeTenYearSavings ? `$${formatCurrency(cumulativeTenYearSavings)}` : '--'}
+                          {hasCumulativeTenYearSavings && <span> saved</span>}
+                        </p>
+                        <p className="metric-chip__caption">
+                          {hasCumulativeTenYearSavings
+                            ? 'Total savings when comparing month-to-month bills over the coming decade.'
+                            : 'Adjust assumptions until Sunrun pulls ahead to reveal decade-long savings.'}
+                        </p>
+                      </div>
+                    </div>
+                    <div className="metric-chip">
+                      <span className="metric-chip__icon" aria-hidden="true">
+                        <InsightsIcon />
+                      </span>
+                      <div>
+                        <p className="metric-chip__label">Peak savings year</p>
+                        <p className="metric-chip__value">
+                          {hasPeakSavings && peakSavings
+                            ? `${peakSavings.year}: $${formatCurrency(peakSavings.Savings * 12)}`
+                            : '--'}
+                        </p>
+                        <p className="metric-chip__caption">
+                          {hasPeakSavings
+                            ? 'Highest projected annual savings before utility increases narrow the gap.'
+                            : 'Savings never overtake SCE with the current entries—try a lower Sunrun rate.'}
+                        </p>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+              )}
             </>
           ) : (
             <div className="empty-state">
@@ -381,7 +530,7 @@ const Calculator = () => {
         <div className="chart-card surface-card">
           <div className="chart-header">
             <h3>Projected monthly bills (next 10 years)</h3>
-            <p>Track the gap between SCE&rsquo;s expected increases and Sunrun&rsquo;s steady 3.5% escalation.</p>
+            <p>Track the gap between SCE&rsquo;s expected increases and Sunrun&rsquo;s steady {SUNRUN_ESCALATION.toFixed(1)}% escalation.</p>
           </div>
 
           <div className="chart-wrapper">
@@ -413,6 +562,7 @@ const Calculator = () => {
           </div>
         </div>
       )}
+
     </section>
   )
 }

--- a/src/Components/Calculator/styles.css
+++ b/src/Components/Calculator/styles.css
@@ -114,6 +114,17 @@ body {
   transform: rotate(12deg);
 }
 
+.surface-card::after {
+  content: '';
+  position: absolute;
+  inset: 1px;
+  border-radius: inherit;
+  border: 1px solid rgba(148, 163, 184, 0.2);
+  background: linear-gradient(135deg, rgba(255, 255, 255, 0.12), rgba(255, 255, 255, 0));
+  z-index: -2;
+  pointer-events: none;
+}
+
 .form-header {
   margin-bottom: 18px;
 }
@@ -361,6 +372,11 @@ button {
   background: linear-gradient(135deg, rgba(254, 243, 199, 0.6), rgba(254, 249, 195, 0.35));
 }
 
+.accent-violet {
+  border-color: rgba(196, 181, 253, 0.5);
+  background: linear-gradient(135deg, rgba(221, 214, 254, 0.55), rgba(233, 213, 255, 0.35));
+}
+
 .empty-state {
   padding: 26px;
   border-radius: 18px;
@@ -430,6 +446,152 @@ button {
   opacity: 0.45;
 }
 
+.savings-summary {
+  margin-top: 26px;
+  padding: 22px 24px;
+  border-radius: 22px;
+  border: 1px solid rgba(148, 163, 184, 0.25);
+  background: linear-gradient(135deg, rgba(226, 232, 240, 0.6), rgba(248, 250, 252, 0.45));
+  display: flex;
+  flex-direction: column;
+  gap: 18px;
+  box-shadow: 0 22px 42px rgba(15, 23, 42, 0.14);
+}
+
+.savings-summary__header h4 {
+  margin: 8px 0 4px;
+  font-size: 1.25rem;
+}
+
+.savings-summary__header p {
+  margin: 0;
+  color: #475569;
+}
+
+.savings-summary__badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  padding: 6px 12px;
+  border-radius: 999px;
+  font-size: 0.85rem;
+  background: rgba(59, 130, 246, 0.14);
+  color: #1d4ed8;
+  font-weight: 600;
+}
+
+.savings-summary__grid {
+  display: grid;
+  gap: 18px;
+  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+}
+
+.metric-chip {
+  display: flex;
+  gap: 14px;
+  align-items: flex-start;
+  padding: 16px 18px;
+  border-radius: 18px;
+  background: rgba(255, 255, 255, 0.75);
+  border: 1px solid rgba(148, 163, 184, 0.28);
+  box-shadow: 0 16px 32px rgba(15, 23, 42, 0.12);
+}
+
+.metric-chip__icon {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 10px;
+  border-radius: 14px;
+  background: linear-gradient(135deg, rgba(37, 99, 235, 0.2), rgba(59, 130, 246, 0.08));
+  color: #1d4ed8;
+}
+
+.metric-chip__label {
+  margin: 0;
+  font-size: 0.9rem;
+  color: #1e293b;
+  font-weight: 600;
+}
+
+.metric-chip__value {
+  margin: 4px 0 6px;
+  font-size: 1.25rem;
+  font-weight: 700;
+  color: #0f172a;
+}
+
+.metric-chip__value span {
+  font-size: 0.95rem;
+  font-weight: 500;
+  color: #2563eb;
+}
+
+.metric-chip__caption {
+  margin: 0;
+  color: #475569;
+  font-size: 0.85rem;
+  line-height: 1.4;
+}
+
+.assumption-panel {
+  margin-top: 20px;
+  padding: 20px 22px;
+  border-radius: 20px;
+  border: 1px solid rgba(148, 163, 184, 0.28);
+  background: linear-gradient(135deg, rgba(236, 253, 245, 0.65), rgba(219, 234, 254, 0.35));
+  box-shadow: 0 20px 40px rgba(15, 23, 42, 0.12);
+  display: flex;
+  flex-direction: column;
+  gap: 18px;
+}
+
+.assumption-panel__header h4 {
+  margin: 0 0 6px;
+  font-size: 1.2rem;
+}
+
+.assumption-panel__header p {
+  margin: 0;
+  color: #475569;
+  font-size: 0.9rem;
+}
+
+.assumption-panel__grid {
+  display: grid;
+  gap: 14px;
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+}
+
+.assumption-metric {
+  padding: 14px 16px;
+  border-radius: 16px;
+  background: rgba(255, 255, 255, 0.78);
+  border: 1px solid rgba(148, 163, 184, 0.3);
+  box-shadow: 0 16px 28px rgba(148, 163, 184, 0.16);
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.assumption-metric__label {
+  font-size: 0.82rem;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+  color: rgba(30, 41, 59, 0.7);
+}
+
+.assumption-metric__value {
+  font-size: 1.35rem;
+  font-weight: 700;
+  color: #0f172a;
+}
+
+.assumption-panel__caption {
+  margin: 0;
+  color: #1e293b;
+  font-size: 0.95rem;
+}
 .chart-header h3 {
   margin: 0;
   font-size: 1.4rem;
@@ -557,6 +719,14 @@ button {
 
   .sunrun-input-row input {
     max-width: 100%;
+  }
+
+  .savings-summary__grid {
+    grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+  }
+
+  .assumption-panel__grid {
+    grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
   }
 }
 


### PR DESCRIPTION
## Summary
- remove the calculator presets and roadmap card so the experience only reflects user-provided inputs
- add percentage-driven assumption metrics and copy updates that highlight the user's projected and baseline increases against Sunrun's escalation
- tighten the projection calculations to recompute bills and savings exclusively from the entered charges, usage, and percentage values

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d8a3ab311c8327976d39d434eb3321