### PR TITLE
Add savings sharing tools and yearly comparison table

### DIFF
--- a/src/Components/Calculator/styles.css
+++ b/src/Components/Calculator/styles.css
@@ -368,6 +368,58 @@ button:hover::after {
   color: #166534;
 }
 
+.projection-actions {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  margin-top: 18px;
+}
+
+.projection-actions__buttons {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12px;
+}
+
+.utility-button {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  padding: 12px 18px;
+  border-radius: 16px;
+  border: none;
+  cursor: pointer;
+  font-weight: 600;
+  background: linear-gradient(135deg, #1d4ed8, #2563eb);
+  color: #fff;
+  box-shadow: 0 18px 38px rgba(37, 99, 235, 0.22);
+  transition: transform 0.3s ease, box-shadow 0.3s ease, filter 0.3s ease;
+}
+
+.utility-button svg {
+  font-size: 1.1rem;
+}
+
+.utility-button:hover {
+  transform: translateY(-2px);
+  box-shadow: 0 24px 48px rgba(37, 99, 235, 0.28);
+}
+
+.utility-button.secondary {
+  background: linear-gradient(135deg, #0ea5e9, #0284c7);
+  box-shadow: 0 18px 38px rgba(14, 165, 233, 0.25);
+}
+
+.utility-button.secondary:hover {
+  box-shadow: 0 24px 48px rgba(14, 165, 233, 0.32);
+}
+
+.projection-actions__status {
+  font-size: 0.85rem;
+  font-weight: 600;
+  color: #0f766e;
+}
+
 .insight-highlights {
   display: grid;
   gap: 16px;
@@ -394,6 +446,14 @@ button:hover::after {
 
 .insight-card:nth-child(3) {
   animation-delay: 2.1s;
+}
+
+.insight-card:nth-child(4) {
+  animation-delay: 2.9s;
+}
+
+.insight-card:nth-child(5) {
+  animation-delay: 3.5s;
 }
 
 .insight-card:hover {
@@ -448,6 +508,16 @@ button:hover::after {
 .accent-violet {
   border-color: rgba(196, 181, 253, 0.5);
   background: linear-gradient(135deg, rgba(221, 214, 254, 0.55), rgba(233, 213, 255, 0.35));
+}
+
+.accent-slate {
+  border-color: rgba(148, 163, 184, 0.45);
+  background: linear-gradient(135deg, rgba(226, 232, 240, 0.6), rgba(241, 245, 249, 0.4));
+}
+
+.accent-indigo {
+  border-color: rgba(165, 180, 252, 0.5);
+  background: linear-gradient(135deg, rgba(199, 210, 254, 0.55), rgba(224, 231, 255, 0.35));
 }
 
 .empty-state {
@@ -518,6 +588,115 @@ button:hover::after {
   width: 220px;
   background: radial-gradient(circle at center, rgba(251, 191, 36, 0.18), transparent 70%);
   opacity: 0.45;
+}
+
+.yearly-breakdown-card {
+  display: flex;
+  flex-direction: column;
+  gap: 18px;
+  background: radial-gradient(circle at top left, rgba(14, 165, 233, 0.12), transparent 60%);
+}
+
+.yearly-breakdown__header {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  gap: 18px;
+  flex-wrap: wrap;
+}
+
+.yearly-breakdown__title {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.yearly-breakdown__badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 6px 12px;
+  border-radius: 999px;
+  background: rgba(14, 165, 233, 0.14);
+  color: #0369a1;
+  font-size: 0.82rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+}
+
+.yearly-breakdown__badge svg {
+  font-size: 1rem;
+}
+
+.yearly-breakdown__header h3 {
+  margin: 0;
+  font-size: 1.5rem;
+}
+
+.yearly-breakdown__header p {
+  margin: 4px 0 0;
+  color: #475569;
+  max-width: 360px;
+}
+
+.yearly-breakdown__table-wrapper {
+  overflow-x: auto;
+  border-radius: 16px;
+  border: 1px solid rgba(148, 163, 184, 0.25);
+  background: rgba(248, 250, 252, 0.7);
+}
+
+.yearly-breakdown__table {
+  width: 100%;
+  min-width: 560px;
+  border-collapse: separate;
+  border-spacing: 0;
+}
+
+.yearly-breakdown__table th,
+.yearly-breakdown__table td {
+  padding: 14px 18px;
+  text-align: right;
+  font-size: 0.95rem;
+  border-bottom: 1px solid rgba(203, 213, 225, 0.6);
+}
+
+.yearly-breakdown__table th:first-child,
+.yearly-breakdown__table td:first-child {
+  text-align: left;
+}
+
+.yearly-breakdown__table thead th {
+  background: rgba(148, 163, 184, 0.12);
+  font-weight: 600;
+  color: #1e293b;
+}
+
+.yearly-breakdown__table tbody tr:nth-child(even) {
+  background: rgba(241, 245, 249, 0.6);
+}
+
+.yearly-breakdown__table tfoot th,
+.yearly-breakdown__table tfoot td {
+  font-weight: 600;
+  background: rgba(37, 99, 235, 0.08);
+}
+
+.yearly-breakdown__table td[data-positive='true'] {
+  color: #047857;
+}
+
+.yearly-breakdown__table td[data-positive='false'] {
+  color: #b91c1c;
+}
+
+.yearly-breakdown__difference-label {
+  display: block;
+  font-size: 0.75rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  opacity: 0.8;
 }
 
 .chart-card:hover {
@@ -836,6 +1015,20 @@ button:hover::after {
 
   .assumption-panel__grid {
     grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+  }
+
+  .projection-actions__buttons {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .utility-button {
+    width: 100%;
+    justify-content: center;
+  }
+
+  .yearly-breakdown__table {
+    min-width: 520px;
   }
 }
 


### PR DESCRIPTION
## Summary
- add clipboard sharing, CSV export, and break-even insights to the calculator results
- extend the insight panel with total spend metrics and responsive styling updates
- render a yearly comparison table to visualise decade-long spend and savings

## Testing
- npm test -- --watchAll=false

------
https://chatgpt.com/codex/tasks/task_e_68d8b57c1a0c83279b8874660b5b2452