### PR TITLE
Refine calculator layout and homeowner export

### DIFF
--- a/src/Components/Calculator/styles.css
+++ b/src/Components/Calculator/styles.css
@@ -124,7 +124,20 @@ body {
 .calculator-grid {
   display: grid;
   gap: 24px;
-  grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
+  align-items: start;
+}
+
+@media (min-width: 1024px) {
+  .calculator-grid {
+    grid-template-columns: minmax(280px, 340px) minmax(0, 1fr);
+  }
+}
+
+.calculator-form {
+  display: flex;
+  flex-direction: column;
+  gap: 20px;
+  height: 100%;
 }
 
 .surface-card {
@@ -185,6 +198,52 @@ body {
   font-size: 0.95rem;
 }
 
+.form-section {
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+}
+
+.form-section__header {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  color: #475569;
+}
+
+.form-section__header span {
+  font-size: 0.8rem;
+  font-weight: 600;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: #2563eb;
+}
+
+.form-section__header p {
+  margin: 0;
+  font-size: 0.9rem;
+  color: #64748b;
+}
+
+.form-grid {
+  display: grid;
+  gap: 16px;
+}
+
+@media (min-width: 640px) {
+  .form-grid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+}
+
+.form-grid .form-group + .form-group {
+  margin-top: 0;
+}
+
+.form-group.full-width {
+  grid-column: 1 / -1;
+}
+
 .form-group {
   display: flex;
   flex-direction: column;
@@ -222,7 +281,13 @@ body {
   display: flex;
   flex-wrap: wrap;
   gap: 12px;
-  margin-top: 24px;
+  margin-top: 8px;
+}
+
+@media (min-width: 640px) {
+  .button-group {
+    justify-content: flex-end;
+  }
 }
 
 button {


### PR DESCRIPTION
## Summary
- compress the usage form into sectioned, two-column grids to keep the calculator compact on larger screens
- restyle form layout spacing and actions for a tidier presentation alongside results
- replace the CSV export with a homeowner-friendly text summary download

## Testing
- CI=true npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d8bf58357c8327b2bcdc1fd4e8b795