### PR TITLE
Stop calculator form from stretching with results

### DIFF
--- a/src/Components/Calculator/styles.css
+++ b/src/Components/Calculator/styles.css
@@ -137,7 +137,6 @@ body {
   display: flex;
   flex-direction: column;
   gap: 20px;
-  height: 100%;
 }
 
 .surface-card {


### PR DESCRIPTION
## Summary
- remove the forced 100% height on the calculator form so it keeps its natural height when results expand

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d8c5cc226c832785a680026ca283a6