### PR TITLE
Revamp bill snapshot presentation

### DIFF
--- a/src/App.test.js
+++ b/src/App.test.js
@@ -1,4 +1,4 @@
-import { render, screen, fireEvent, waitFor } from '@testing-library/react'
+import { render, screen, fireEvent, waitFor, within } from '@testing-library/react'
 import Calculator from './Components/Calculator/calculator'
 
 const fillRequiredFields = (rateChange) => {
@@ -18,7 +18,11 @@ const submitForm = () => {
 
 const expectProjectedBillToBe = async (value) => {
   await waitFor(() => {
-    expect(screen.getByText(/the monthly bill with change is/i)).toHaveTextContent(`$ ${value}`)
+    const label = screen.getByText(/projected monthly bill/i)
+    const cardContent = label.closest('.bill-card__content')
+
+    expect(cardContent).not.toBeNull()
+    expect(within(cardContent).getByText(new RegExp(`\\$${value}`))).toBeInTheDocument()
   })
 }
 

--- a/src/Components/Calculator/calculator.js
+++ b/src/Components/Calculator/calculator.js
@@ -3,12 +3,7 @@ import { ComposedChart, Line, Area, XAxis, YAxis, CartesianGrid, Tooltip, Legend
 import AttachMoneyIcon from '@mui/icons-material/AttachMoney'
 import BoltTwoToneIcon from '@mui/icons-material/BoltTwoTone'
 import SolarPowerTwoToneIcon from '@mui/icons-material/SolarPowerTwoTone'
-import Divider from '@mui/material/Divider'
-import List from '@mui/material/List'
-import ListItem from '@mui/material/ListItem'
-import ListItemText from '@mui/material/ListItemText'
 import PowerOutlinedIcon from '@mui/icons-material/PowerOutlined'
-import Box from '@mui/material/Box'
 import PercentIcon from '@mui/icons-material/Percent'
 import TrendingUpIcon from '@mui/icons-material/TrendingUp'
 import InsightsIcon from '@mui/icons-material/Insights'
@@ -16,6 +11,7 @@ import EventAvailableIcon from '@mui/icons-material/EventAvailable'
 import DownloadIcon from '@mui/icons-material/Download'
 import ContentCopyIcon from '@mui/icons-material/ContentCopy'
 import TableChartIcon from '@mui/icons-material/TableChart'
+import SavingsTwoToneIcon from '@mui/icons-material/SavingsTwoTone'
 import './styles.css'  // Importing the updated CSS file
 
 const xYearsLabel = [
@@ -71,19 +67,6 @@ const computeProjectedBills = (initialBill, sunRunStartMonthlyCost, firstYearInc
   return { sunrunBills, sceBills }
 }
 
-const listStyles = {
-  py: 0,
-  width: '100%',
-  borderRadius: 3,
-  border: '1px solid rgba(148, 163, 184, 0.35)',
-  backgroundColor: 'rgba(255,255,255,0.85)',
-  boxShadow: '0 18px 45px rgba(15, 23, 42, 0.12)',
-  backdropFilter: 'blur(14px)'
-}
-
-const listWrapperStyles = {
-  width: '100%'
-}
 const currencyFormatter = (value) => {
   if (value === 0) {
     return '$0'
@@ -343,6 +326,8 @@ const Calculator = () => {
     : 'Sunrun never surpasses the projected SCE costs within this projection window.'
 
   const chargesNumber = charges ? parseFloat(charges) : null
+  const usageNumber = usage ? parseFloat(usage) : null
+  const avgPerMonthCostNumber = avgPerMonthCost ? parseFloat(avgPerMonthCost) : null
   const annualUsageNumber = annualUsage ? parseFloat(annualUsage) : null
   const monthlyUsageKwh = Number.isFinite(annualUsageNumber) ? annualUsageNumber / 12 : null
   const currentAnnualBill = Number.isFinite(chargesNumber) ? chargesNumber * 12 : null
@@ -469,6 +454,8 @@ const Calculator = () => {
 
     return value.toLocaleString(undefined, { minimumFractionDigits: 0, maximumFractionDigits: 0, ...options })
   }
+
+  const projectedIncreaseDisplay = formatPercentage(Number.parseFloat(scePecentage))
 
   const animationTriggerKey = useMemo(() => [
     rate ?? 'null',
@@ -762,58 +749,141 @@ const Calculator = () => {
 
           {rate !== null ? (
             <>
-              <Box sx={listWrapperStyles}>
-                <List sx={listStyles}>
-                  <ListItem className="result-item">
-                    <ListItemText primary={`The rate is ${rate} per kWh.`} secondary={`($ ${charges || 0} / ${usage || 0})`} />
-                  </ListItem>
-                  <Divider component="li" />
-                  <ListItem className="result-item">
-                    <ListItemText primary={`The average monthly cost is ${avgPerMonthCost}`} secondary={`(${annualUsage || 0} × $ ${rate} / 12)`} />
-                  </ListItem>
-                  <Divider component="li" />
-                  <ListItem className="result-item">
-                    <ListItemText primary={`The monthly bill with change is $ ${projectedMonthlyBill}`} secondary={`(${avgPerMonthCost} × (1 + ${scePecentage || 0} / 100))`} />
-                  </ListItem>
-                  <Divider component="li" />
-                  <ListItem className="result-item">
-                    <ListItemText
-                      primary={`Average monthly usage: ${monthlyUsageKwh !== null ? `${formatNumber(monthlyUsageKwh, { maximumFractionDigits: 0 })} kWh` : 'Add annual usage to unlock'}`}
-                      secondary={monthlyUsageKwh !== null ? `${formatNumber(annualUsageNumber, { maximumFractionDigits: 0 })} kWh / 12` : ''}
-                    />
-                  </ListItem>
-                  <Divider component="li" />
-                  <ListItem className="result-item">
-                    <ListItemText
-                      primary={`Current annual SCE spend: ${currentAnnualBill !== null ? `$${formatCurrency(currentAnnualBill)}` : '--'}`}
-                      secondary={currentAnnualBill !== null && chargesNumber !== null ? `(${formatCurrency(chargesNumber, { minimumFractionDigits: 2, maximumFractionDigits: 2 })} × 12)` : 'Enter a monthly charge to calculate.'}
-                    />
-                  </ListItem>
-                  <Divider component="li" />
-                  <ListItem className="result-item">
-                    <ListItemText
-                      primary={`Projected annual SCE bill: ${projectedAnnualBill !== null ? `$${formatCurrency(projectedAnnualBill)}` : '--'}`}
-                      secondary={projectedAnnualBill !== null ? `(${formatCurrency(projectedMonthlyBillNumber, { minimumFractionDigits: 2, maximumFractionDigits: 2 })} × 12)` : 'Provide projected increases to calculate.'}
-                    />
-                  </ListItem>
-                  <Divider component="li" />
-                  <ListItem className="result-item">
-                    <ListItemText
-                      primary={`Sunrun annual cost: ${sunrunAnnualCost !== null ? `$${formatCurrency(sunrunAnnualCost)}` : '--'}`}
-                      secondary={sunrunAnnualCost !== null ? `(${formatCurrency(sunrunMonthlyCostNumber, { minimumFractionDigits: 2, maximumFractionDigits: 2 })} × 12)` : 'Enter a Sunrun monthly cost above.'}
-                    />
-                  </ListItem>
-                  <Divider component="li" />
-                  <ListItem className="result-item">
-                    <ListItemText
-                      primary={`Annual savings vs. Sunrun plan: ${projectedPlanAnnualSavings !== null ? `$${formatCurrencyAbsolute(projectedPlanAnnualSavings)}` : '--'}`}
-                      secondary={projectedPlanAnnualSavings !== null
-                        ? `${projectedPlanAnnualSavings >= 0 ? 'Potential savings' : 'Additional annual cost'} using your projections.`
+              <div className="bill-snapshot-grid animatable" data-animate style={{ '--delay': '0.16s' }}>
+                <article className="bill-card accent-sky">
+                  <span className="bill-card__icon"><BoltTwoToneIcon /></span>
+                  <div className="bill-card__content">
+                    <span className="bill-card__label">Current rate</span>
+                    <span className="bill-card__value">
+                      ${rate}
+                      <span className="bill-card__unit">/ kWh</span>
+                    </span>
+                    <p className="bill-card__hint">
+                      {chargesNumber !== null && usageNumber !== null
+                        ? `Based on $${formatCurrency(chargesNumber, { minimumFractionDigits: 2, maximumFractionDigits: 2 })} for ${formatNumber(usageNumber, { minimumFractionDigits: 0, maximumFractionDigits: 0 })} kWh.`
+                        : 'Add monthly charges and usage to calculate a rate.'}
+                    </p>
+                  </div>
+                </article>
+
+                <article className="bill-card accent-lime">
+                  <span className="bill-card__icon"><AttachMoneyIcon /></span>
+                  <div className="bill-card__content">
+                    <span className="bill-card__label">Average monthly cost</span>
+                    <span className="bill-card__value">
+                      {avgPerMonthCostNumber !== null
+                        ? `$${formatCurrency(avgPerMonthCostNumber, { minimumFractionDigits: 2, maximumFractionDigits: 2 })}`
+                        : '--'}
+                    </span>
+                    <p className="bill-card__hint">
+                      {annualUsageNumber !== null
+                        ? `Derived from ${formatNumber(annualUsageNumber, { maximumFractionDigits: 0 })} kWh each year.`
+                        : 'Add annual usage to reveal a monthly average.'}
+                    </p>
+                  </div>
+                </article>
+
+                <article className="bill-card accent-amber">
+                  <span className="bill-card__icon"><TrendingUpIcon /></span>
+                  <div className="bill-card__content">
+                    <span className="bill-card__label">Projected monthly bill</span>
+                    <span className="bill-card__value">
+                      {projectedMonthlyBillNumber !== null
+                        ? `$${formatCurrency(projectedMonthlyBillNumber, { minimumFractionDigits: 2, maximumFractionDigits: 2 })}`
+                        : '--'}
+                    </span>
+                    <p className="bill-card__hint">
+                      {projectedMonthlyBillNumber !== null && projectedIncreaseDisplay !== '--'
+                        ? `Includes a ${projectedIncreaseDisplay} annual utility increase.`
+                        : 'Update the projected increase to see how future rates shift.'}
+                    </p>
+                  </div>
+                </article>
+
+                <article className="bill-card accent-indigo">
+                  <span className="bill-card__icon"><PowerOutlinedIcon /></span>
+                  <div className="bill-card__content">
+                    <span className="bill-card__label">Average usage</span>
+                    <span className="bill-card__value">
+                      {monthlyUsageKwh !== null ? `${formatNumber(monthlyUsageKwh, { maximumFractionDigits: 0 })} kWh` : '--'}
+                    </span>
+                    <p className="bill-card__hint">
+                      {monthlyUsageKwh !== null
+                        ? `${formatNumber(annualUsageNumber, { maximumFractionDigits: 0 })} kWh each year ÷ 12 months.`
+                        : 'Add annual usage to unlock this insight.'}
+                    </p>
+                  </div>
+                </article>
+
+                <article className="bill-card accent-slate">
+                  <span className="bill-card__icon"><EventAvailableIcon /></span>
+                  <div className="bill-card__content">
+                    <span className="bill-card__label">Current annual spend</span>
+                    <span className="bill-card__value">
+                      {currentAnnualBill !== null ? `$${formatCurrency(currentAnnualBill)}` : '--'}
+                    </span>
+                    <p className="bill-card__hint">
+                      {currentAnnualBill !== null && chargesNumber !== null
+                        ? `$${formatCurrency(chargesNumber, { minimumFractionDigits: 2, maximumFractionDigits: 2 })}/mo today.`
+                        : 'Enter a monthly charge to calculate.'}
+                    </p>
+                  </div>
+                </article>
+
+                <article className="bill-card accent-blue">
+                  <span className="bill-card__icon"><InsightsIcon /></span>
+                  <div className="bill-card__content">
+                    <span className="bill-card__label">Projected annual SCE bill</span>
+                    <span className="bill-card__value">
+                      {projectedAnnualBill !== null ? `$${formatCurrency(projectedAnnualBill)}` : '--'}
+                    </span>
+                    <p className="bill-card__hint">
+                      {projectedAnnualBill !== null && projectedMonthlyBillNumber !== null
+                        ? `Equivalent to $${formatCurrency(projectedMonthlyBillNumber, { minimumFractionDigits: 2, maximumFractionDigits: 2 })}/mo.`
+                        : 'Provide projected increases to calculate.'}
+                    </p>
+                  </div>
+                </article>
+
+                <article className="bill-card accent-emerald">
+                  <span className="bill-card__icon"><SolarPowerTwoToneIcon /></span>
+                  <div className="bill-card__content">
+                    <span className="bill-card__label">Sunrun annual cost</span>
+                    <span className="bill-card__value">
+                      {sunrunAnnualCost !== null ? `$${formatCurrency(sunrunAnnualCost)}` : '--'}
+                    </span>
+                    <p className="bill-card__hint">
+                      {sunrunAnnualCost !== null && sunrunMonthlyCostNumber !== null
+                        ? `$${formatCurrency(sunrunMonthlyCostNumber, { minimumFractionDigits: 2, maximumFractionDigits: 2 })}/mo plan.`
+                        : 'Enter a Sunrun monthly cost above.'}
+                    </p>
+                  </div>
+                </article>
+
+                <article
+                  className={`bill-card ${projectedPlanAnnualSavings !== null && projectedPlanAnnualSavings < 0 ? 'accent-rose is-negative' : 'accent-emerald'}`}
+                >
+                  <span className="bill-card__icon"><SavingsTwoToneIcon /></span>
+                  <div className="bill-card__content">
+                    <span className="bill-card__label">Difference vs. Sunrun</span>
+                    <span className="bill-card__value">
+                      {projectedPlanAnnualSavings !== null
+                        ? `$${formatCurrencyAbsolute(projectedPlanAnnualSavings, { minimumFractionDigits: 0, maximumFractionDigits: 0 })}`
+                        : '--'}
+                      {projectedPlanAnnualSavings !== null && (
+                        <span className="bill-card__unit">/ yr {projectedPlanAnnualSavings >= 0 ? 'saved' : 'added cost'}</span>
+                      )}
+                    </span>
+                    <p className="bill-card__hint">
+                      {projectedPlanAnnualSavings !== null
+                        ? projectedPlanAnnualSavings >= 0
+                          ? 'Projected annual savings compared with the Sunrun plan.'
+                          : 'Projected annual cost above the Sunrun plan.'
                         : 'Provide Sunrun and projected utility costs to compare.'}
-                    />
-                  </ListItem>
-                </List>
-              </Box>
+                    </p>
+                  </div>
+                </article>
+              </div>
 
               <div className="sunrun-input-container animatable" data-animate style={{ '--delay': '0.18s' }}>
                 <p className="warning-label">Compare against a Sunrun plan</p>

--- a/src/Components/Calculator/styles.css
+++ b/src/Components/Calculator/styles.css
@@ -361,16 +361,215 @@ button:hover::after {
   color: #64748b;
 }
 
-.result-item .MuiListItemText-primary {
-  font-weight: 600;
-  color: #0f172a;
-  font-size: 1.05rem;
+.bill-snapshot-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+  gap: 16px;
 }
 
-.result-item .MuiListItemText-secondary {
-  margin-top: 4px;
+@media (min-width: 768px) {
+  .bill-snapshot-grid {
+    gap: 20px;
+  }
+}
+
+.bill-card {
+  position: relative;
+  display: flex;
+  gap: 16px;
+  align-items: flex-start;
+  padding: 20px 22px;
+  border-radius: 20px;
+  background: linear-gradient(135deg, rgba(255, 255, 255, 0.92), rgba(248, 250, 252, 0.97));
+  border: 1px solid var(--accent-border, rgba(148, 163, 184, 0.22));
+  box-shadow: 0 18px 40px rgba(15, 23, 42, 0.12);
+  overflow: hidden;
+  transition: transform 0.35s cubic-bezier(0.16, 1, 0.3, 1), box-shadow 0.35s ease, border-color 0.35s ease;
+}
+
+.bill-card::before {
+  content: '';
+  position: absolute;
+  inset: -60px -40px auto auto;
+  width: 180px;
+  height: 180px;
+  background: radial-gradient(circle at center, var(--accent-glow, rgba(148, 163, 184, 0.18)), transparent 70%);
+  opacity: 0.85;
+  transform: rotate(18deg);
+  z-index: 0;
+}
+
+.bill-card:hover {
+  transform: translateY(-6px);
+  box-shadow: 0 26px 55px rgba(15, 23, 42, 0.16);
+  border-color: var(--accent-border-hover, rgba(148, 163, 184, 0.32));
+}
+
+.bill-card > * {
+  position: relative;
+  z-index: 1;
+}
+
+.bill-card__icon {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 44px;
+  height: 44px;
+  border-radius: 14px;
+  background: var(--accent-soft, rgba(148, 163, 184, 0.16));
+  color: var(--accent-color, #0f172a);
+  box-shadow: 0 12px 28px var(--accent-shadow, rgba(15, 23, 42, 0.12));
+}
+
+.bill-card__label {
+  display: block;
+  font-size: 0.8rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
   color: #64748b;
-  font-size: 0.9rem;
+  margin-bottom: 6px;
+  font-weight: 600;
+}
+
+.bill-card__value {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: baseline;
+  gap: 6px;
+  font-size: 1.55rem;
+  font-weight: 700;
+  color: #0f172a;
+  margin-bottom: 6px;
+}
+
+.bill-card__unit {
+  font-size: 0.95rem;
+  color: #475569;
+  font-weight: 600;
+}
+
+.bill-card__hint {
+  margin: 0;
+  color: #64748b;
+  font-size: 0.92rem;
+  line-height: 1.5;
+}
+
+.bill-card.accent-sky {
+  --accent-color: #0284c7;
+  --accent-soft: rgba(56, 189, 248, 0.18);
+  --accent-border: rgba(14, 165, 233, 0.28);
+  --accent-border-hover: rgba(14, 165, 233, 0.45);
+  --accent-shadow: rgba(14, 165, 233, 0.25);
+  --accent-glow: rgba(56, 189, 248, 0.24);
+}
+
+.bill-card.accent-lime {
+  --accent-color: #3f6212;
+  --accent-soft: rgba(163, 230, 53, 0.22);
+  --accent-border: rgba(132, 204, 22, 0.28);
+  --accent-border-hover: rgba(132, 204, 22, 0.45);
+  --accent-shadow: rgba(132, 204, 22, 0.24);
+  --accent-glow: rgba(190, 242, 100, 0.28);
+}
+
+.bill-card.accent-amber {
+  --accent-color: #b45309;
+  --accent-soft: rgba(251, 191, 36, 0.24);
+  --accent-border: rgba(251, 191, 36, 0.32);
+  --accent-border-hover: rgba(251, 191, 36, 0.5);
+  --accent-shadow: rgba(251, 191, 36, 0.24);
+  --accent-glow: rgba(251, 191, 36, 0.28);
+}
+
+.bill-card.accent-indigo {
+  --accent-color: #4338ca;
+  --accent-soft: rgba(165, 180, 252, 0.24);
+  --accent-border: rgba(129, 140, 248, 0.32);
+  --accent-border-hover: rgba(129, 140, 248, 0.52);
+  --accent-shadow: rgba(129, 140, 248, 0.3);
+  --accent-glow: rgba(129, 140, 248, 0.26);
+}
+
+.bill-card.accent-slate {
+  --accent-color: #1f2937;
+  --accent-soft: rgba(148, 163, 184, 0.26);
+  --accent-border: rgba(148, 163, 184, 0.35);
+  --accent-border-hover: rgba(100, 116, 139, 0.45);
+  --accent-shadow: rgba(100, 116, 139, 0.22);
+  --accent-glow: rgba(148, 163, 184, 0.24);
+}
+
+.bill-card.accent-blue {
+  --accent-color: #1d4ed8;
+  --accent-soft: rgba(96, 165, 250, 0.22);
+  --accent-border: rgba(59, 130, 246, 0.32);
+  --accent-border-hover: rgba(37, 99, 235, 0.52);
+  --accent-shadow: rgba(59, 130, 246, 0.28);
+  --accent-glow: rgba(96, 165, 250, 0.28);
+}
+
+.bill-card.accent-emerald {
+  --accent-color: #047857;
+  --accent-soft: rgba(52, 211, 153, 0.22);
+  --accent-border: rgba(16, 185, 129, 0.35);
+  --accent-border-hover: rgba(16, 185, 129, 0.5);
+  --accent-shadow: rgba(16, 185, 129, 0.24);
+  --accent-glow: rgba(52, 211, 153, 0.24);
+}
+
+.bill-card.accent-rose {
+  --accent-color: #be123c;
+  --accent-soft: rgba(244, 63, 94, 0.2);
+  --accent-border: rgba(244, 63, 94, 0.32);
+  --accent-border-hover: rgba(225, 29, 72, 0.5);
+  --accent-shadow: rgba(244, 63, 94, 0.28);
+  --accent-glow: rgba(244, 63, 94, 0.26);
+}
+
+.bill-card.accent-sky .bill-card__value {
+  color: #0369a1;
+}
+
+.bill-card.accent-lime .bill-card__value {
+  color: #3f6212;
+}
+
+.bill-card.accent-amber .bill-card__value {
+  color: #b45309;
+}
+
+.bill-card.accent-indigo .bill-card__value {
+  color: #3730a3;
+}
+
+.bill-card.accent-slate .bill-card__value {
+  color: #1f2937;
+}
+
+.bill-card.accent-blue .bill-card__value {
+  color: #1d4ed8;
+}
+
+.bill-card.accent-emerald .bill-card__value {
+  color: #047857;
+}
+
+.bill-card.accent-rose .bill-card__value,
+.bill-card.is-negative .bill-card__value {
+  color: #be123c;
+}
+
+@media (max-width: 640px) {
+  .bill-card {
+    padding: 18px;
+    border-radius: 18px;
+  }
+
+  .bill-card__value {
+    font-size: 1.35rem;
+  }
 }
 
 .sunrun-input-container {


### PR DESCRIPTION
## Summary
- redesign the bill snapshot panel into colorful cards with contextual messaging for each metric
- add accent styling variants for the new bill snapshot cards, including negative states
- update calculator tests to align with the refreshed bill snapshot layout

## Testing
- npm test -- --watchAll=false

------
https://chatgpt.com/codex/tasks/task_e_68d8d01d5fd883279ca767308aac0efa