### PR TITLE
Add validation boundaries and helper text to calculator inputs

### DIFF
--- a/src/App.test.js
+++ b/src/App.test.js
@@ -44,11 +44,19 @@ test('calculates projected monthly bill with no percentage change', async () => 
   await expectProjectedBillToBe('120.00')
 })
 
-test('calculates projected monthly bill with a 5% decrease', async () => {
+test('blocks projections when the rate decrease falls outside the supported range', async () => {
   render(<Calculator />)
 
   fillRequiredFields('-5')
   submitForm()
 
-  await expectProjectedBillToBe('114.00')
+  const [, , , rateChangeInput] = screen.getAllByRole('spinbutton')
+  const helper = screen.getByText('Use a rate increase between 0% and 50% to keep projections realistic.')
+
+  await waitFor(() => {
+    expect(rateChangeInput).toHaveClass('input-error')
+    expect(helper).toHaveClass('input-helper--error')
+  })
+
+  expect(screen.queryByText(/\$114\.00/)).not.toBeInTheDocument()
 })

--- a/src/Components/Calculator/styles.css
+++ b/src/Components/Calculator/styles.css
@@ -276,6 +276,22 @@ body {
   box-shadow: 0 0 0 4px rgba(37, 99, 235, 0.15);
 }
 
+.input-helper {
+  margin: 0;
+  font-size: 0.82rem;
+  color: #64748b;
+}
+
+.input-helper--error {
+  color: #dc2626;
+}
+
+.form-group input.input-error,
+.sunrun-input-row input.input-error {
+  border-color: #dc2626;
+  box-shadow: 0 0 0 4px rgba(220, 38, 38, 0.12);
+}
+
 .button-group {
   display: flex;
   flex-wrap: wrap;


### PR DESCRIPTION
## Summary
- add shared field constraints and inline helper messaging to calculator numeric inputs
- validate form submission and Sunrun projections to prevent out-of-range entries from skewing results
- style error states and adjust tests to cover the new validation flow

## Testing
- npm test -- --watchAll=false

------
https://chatgpt.com/codex/tasks/task_e_68d9b3bf0c588327b98855a0e7f52091