### PR TITLE
Add helper message for Sunrun projection validation

### DIFF
--- a/src/Components/Calculator/styles.css
+++ b/src/Components/Calculator/styles.css
@@ -626,7 +626,7 @@ button:hover::after {
 }
 
 .sunrun-helper-message {
-  margin: 0;
+  margin: 8px 0 0;
   font-size: 0.9rem;
   line-height: 1.4;
   color: #b91c1c;


### PR DESCRIPTION
## Summary
- add state to capture a helper message when the Sunrun projection inputs are invalid
- reset the message when projections recalculate successfully and surface it next to the Update projection control
- style the helper text to appear as a concise warning near the button

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d9b33a99f88327bd91916b32d6326d