### PR TITLE
Adjust calculator button sizing on small screens

### DIFF
--- a/src/Components/Calculator/styles.css
+++ b/src/Components/Calculator/styles.css
@@ -1571,6 +1571,23 @@ button:hover::after {
   }
 }
 
+@media (max-width: 480px) {
+  .button-group {
+    flex-direction: row;
+    justify-content: center;
+    align-items: stretch;
+    flex-wrap: wrap;
+  }
+
+  .button-group button {
+    flex: 1 1 140px;
+    padding: 11px 16px;
+    font-size: 0.95rem;
+    width: auto;
+    max-width: 200px;
+  }
+}
+
 @media (min-width: 1100px) {
   .calculator-container {
     padding: 0 10px;


### PR DESCRIPTION
## Summary
- add a mobile-only media query to refine the calculator button layout
- reduce button padding, font-size, and flex basis so controls stay comfortable on very small screens

## Testing
- npm start

------
https://chatgpt.com/codex/tasks/task_e_68d9b29a36a88327bb67b27b3b48a100