### PR TITLE
Align sunrun projections with initial cost

### DIFF
--- a/src/Components/Calculator/calculator.js
+++ b/src/Components/Calculator/calculator.js
@@ -80,21 +80,15 @@ const computeProjectedBills = (initialBill, sunRunStartMonthlyCost, firstYearInc
   const firstYearFactor = 1 + safeFirstYearIncrease / 100
   const ongoingFactor = 1 + safeOngoingIncrease / 100
 
-  const sunrunBills = []
-  const sceBills = []
-
-  let currentSunrunBill = sunRunStartMonthlyCost * sunrunIncrease
-  let currentSceBill = initialBill * firstYearFactor
-
-  sunrunBills.push(currentSunrunBill)
-  sceBills.push(currentSceBill)
+  const sunrunBills = [sunRunStartMonthlyCost]
+  const sceBills = [initialBill * firstYearFactor]
 
   for (let i = 1; i < totalYears; i++) {
-    currentSunrunBill *= sunrunIncrease
-    currentSceBill *= ongoingFactor
+    const nextSunrunBill = sunrunBills[i - 1] * sunrunIncrease
+    const nextSceBill = sceBills[i - 1] * ongoingFactor
 
-    sunrunBills.push(currentSunrunBill)
-    sceBills.push(currentSceBill)
+    sunrunBills.push(nextSunrunBill)
+    sceBills.push(nextSceBill)
   }
 
   return { sunrunBills, sceBills }


### PR DESCRIPTION
## Summary
- push the provided Sunrun starting cost as the first value in the projection series
- escalate both Sunrun and SCE projections from their prior year values to keep them aligned
- manually verified the chart and summary outputs continue to reflect the corrected series

## Testing
- npm start

------
https://chatgpt.com/codex/tasks/task_e_68d9babc67608327900374b555decf2d