### PR TITLE
Add dynamic projection horizon selection

### DIFF
--- a/src/Components/Calculator/styles.css
+++ b/src/Components/Calculator/styles.css
@@ -668,6 +668,47 @@ button:hover::after {
   color: #166534;
 }
 
+.projection-length-control {
+  margin-top: 22px;
+  padding: 16px;
+  border-radius: 18px;
+  border: 1px solid rgba(34, 197, 94, 0.25);
+  background: rgba(236, 253, 245, 0.65);
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.projection-length-control label {
+  font-weight: 600;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  color: #166534;
+}
+
+.projection-length-control input[type='range'] {
+  width: 100%;
+  accent-color: #22c55e;
+  cursor: pointer;
+}
+
+.projection-length-control__values {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: space-between;
+  gap: 8px;
+  font-size: 0.9rem;
+  font-weight: 600;
+  color: #166534;
+}
+
+.projection-length-control__caption {
+  margin: 0;
+  font-size: 0.85rem;
+  color: #047857;
+}
+
 .projection-actions {
   display: flex;
   flex-direction: column;


### PR DESCRIPTION
## Summary
- replace the fixed year labels with helper-generated values tied to the selected projection window and reuse them across calculations and summaries
- add a projection length slider that updates the header, chart, and scenario views to respect the chosen horizon
- refresh the clipboard and download exports plus styling to surface the dynamic projection range

## Testing
- npm test -- --watchAll=false

------
https://chatgpt.com/codex/tasks/task_e_68d9bdeae12c8327901959911a2abf41