### PR TITLE
Enhance calculator chart gradients and styling

### DIFF
--- a/src/Components/Calculator/calculator.js
+++ b/src/Components/Calculator/calculator.js
@@ -114,6 +114,12 @@ const currencyFormatter = (value) => {
   return `$${value.toLocaleString(undefined, { minimumFractionDigits: 0, maximumFractionDigits: 0 })}`
 }
 
+const tooltipAccentColors = {
+  SunRun: '#60a5fa',
+  SCE: '#f472b6',
+  Savings: '#818cf8'
+}
+
 const ChartTooltip = ({ active, payload, label }) => {
   if (!active || !payload || payload.length === 0) {
     return null
@@ -123,17 +129,25 @@ const ChartTooltip = ({ active, payload, label }) => {
   const sce = payload.find((item) => item.dataKey === 'SCE')
   const savings = payload.find((item) => item.dataKey === 'Savings')
 
+  const getAccentColor = (item) => {
+    if (!item) {
+      return undefined
+    }
+
+    return tooltipAccentColors[item.dataKey] ?? item.color ?? item.stroke ?? undefined
+  }
+
   return (
     <div className="chart-tooltip">
       <p className="chart-tooltip__label">{label}</p>
       {sunrun && (
-        <div className="chart-tooltip__item" style={{ '--color': sunrun.color }}>
+        <div className="chart-tooltip__item" style={{ '--color': getAccentColor(sunrun) }}>
           <span>Sunrun</span>
           <strong>${sunrun.value.toFixed(2)}</strong>
         </div>
       )}
       {sce && (
-        <div className="chart-tooltip__item" style={{ '--color': sce.color }}>
+        <div className="chart-tooltip__item" style={{ '--color': getAccentColor(sce) }}>
           <span>SCE</span>
           <strong>${sce.value.toFixed(2)}</strong>
         </div>
@@ -1547,9 +1561,20 @@ const Calculator = () => {
                 margin={{ top: 36, right: 36, bottom: 56, left: 24 }}
               >
                 <defs>
+                  <linearGradient id="sunrunLineGradient" x1="0" y1="0" x2="1" y2="0">
+                    <stop offset="0%" stopColor="#38bdf8" />
+                    <stop offset="48%" stopColor="#6366f1" />
+                    <stop offset="100%" stopColor="#a855f7" />
+                  </linearGradient>
+                  <linearGradient id="sceLineGradient" x1="0" y1="0" x2="1" y2="0">
+                    <stop offset="0%" stopColor="#f472b6" />
+                    <stop offset="52%" stopColor="#c084fc" />
+                    <stop offset="100%" stopColor="#7c3aed" />
+                  </linearGradient>
                   <linearGradient id="savingsGradient" x1="0" y1="0" x2="0" y2="1">
-                    <stop offset="5%" stopColor="#22c55e" stopOpacity={0.35} />
-                    <stop offset="95%" stopColor="#22c55e" stopOpacity={0.05} />
+                    <stop offset="0%" stopColor="#60a5fa" stopOpacity={0.38} />
+                    <stop offset="46%" stopColor="#818cf8" stopOpacity={0.22} />
+                    <stop offset="100%" stopColor="#a855f7" stopOpacity={0.08} />
                   </linearGradient>
                 </defs>
                 <CartesianGrid strokeDasharray="4 4" stroke="#cbd5f5" vertical={false} />
@@ -1578,8 +1603,22 @@ const Calculator = () => {
                   />
                 )}
                 <Area type="monotone" dataKey="Savings" stroke="none" fill="url(#savingsGradient)" fillOpacity={1} legendType="none" />
-                <Line type="monotone" dataKey="SunRun" stroke="#2563eb" strokeWidth={3} dot={{ r: 4 }} activeDot={{ r: 6 }} />
-                <Line type="monotone" dataKey="SCE" stroke="#f97316" strokeWidth={3} dot={{ r: 4 }} activeDot={{ r: 6 }} />
+                <Line
+                  type="monotone"
+                  dataKey="SunRun"
+                  stroke="url(#sunrunLineGradient)"
+                  strokeWidth={3.5}
+                  dot={{ r: 5.5, strokeWidth: 2, stroke: '#c7d2fe', fill: '#4338ca' }}
+                  activeDot={{ r: 8, strokeWidth: 0, fill: '#4338ca' }}
+                />
+                <Line
+                  type="monotone"
+                  dataKey="SCE"
+                  stroke="url(#sceLineGradient)"
+                  strokeWidth={3.5}
+                  dot={{ r: 5.5, strokeWidth: 2, stroke: '#fbcfe8', fill: '#be185d' }}
+                  activeDot={{ r: 8, strokeWidth: 0, fill: '#be185d' }}
+                />
               </ComposedChart>
             </ResponsiveContainer>
           </div>

--- a/src/Components/Calculator/styles.css
+++ b/src/Components/Calculator/styles.css
@@ -1564,6 +1564,28 @@ button:hover::after {
   font-size: 0.95rem;
 }
 
+.recharts-line-SunRun path {
+  filter: drop-shadow(0 0 10px rgba(99, 102, 241, 0.35));
+}
+
+.recharts-line-SCE path {
+  filter: drop-shadow(0 0 10px rgba(236, 72, 153, 0.32));
+}
+
+.recharts-line-SunRun .recharts-dot {
+  fill: #4338ca !important;
+  stroke: rgba(199, 210, 254, 0.95) !important;
+  stroke-width: 2px;
+  filter: drop-shadow(0 0 6px rgba(79, 70, 229, 0.45));
+}
+
+.recharts-line-SCE .recharts-dot {
+  fill: #be185d !important;
+  stroke: rgba(251, 207, 232, 0.95) !important;
+  stroke-width: 2px;
+  filter: drop-shadow(0 0 6px rgba(244, 114, 182, 0.4));
+}
+
 .recharts-default-legend {
   padding-right: 14px !important;
 }


### PR DESCRIPTION
## Summary
- introduce gradient strokes and refreshed savings fill for the calculator chart lines
- align tooltip accents and dot styling with the new palette for consistent theming
- add CSS glow treatments for Sunrun and SCE series elements

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d9c1f7807c8327ad4d1fcd64078d44