### PR TITLE
Add gradient styling to calculator chart lines

### DIFF
--- a/src/Components/Calculator/calculator.js
+++ b/src/Components/Calculator/calculator.js
@@ -115,9 +115,9 @@ const currencyFormatter = (value) => {
 }
 
 const tooltipAccentColors = {
-  SunRun: '#60a5fa',
+  SunRun: '#6366f1',
   SCE: '#f472b6',
-  Savings: '#818cf8'
+  Savings: '#a855f7'
 }
 
 const ChartTooltip = ({ active, payload, label }) => {
@@ -1563,18 +1563,19 @@ const Calculator = () => {
                 <defs>
                   <linearGradient id="sunrunLineGradient" x1="0" y1="0" x2="1" y2="0">
                     <stop offset="0%" stopColor="#38bdf8" />
-                    <stop offset="48%" stopColor="#6366f1" />
-                    <stop offset="100%" stopColor="#a855f7" />
+                    <stop offset="45%" stopColor="#6366f1" />
+                    <stop offset="100%" stopColor="#8b5cf6" />
                   </linearGradient>
                   <linearGradient id="sceLineGradient" x1="0" y1="0" x2="1" y2="0">
                     <stop offset="0%" stopColor="#f472b6" />
-                    <stop offset="52%" stopColor="#c084fc" />
+                    <stop offset="48%" stopColor="#d946ef" />
                     <stop offset="100%" stopColor="#7c3aed" />
                   </linearGradient>
                   <linearGradient id="savingsGradient" x1="0" y1="0" x2="0" y2="1">
-                    <stop offset="0%" stopColor="#60a5fa" stopOpacity={0.38} />
-                    <stop offset="46%" stopColor="#818cf8" stopOpacity={0.22} />
-                    <stop offset="100%" stopColor="#a855f7" stopOpacity={0.08} />
+                    <stop offset="0%" stopColor="#38bdf8" stopOpacity={0.42} />
+                    <stop offset="35%" stopColor="#6366f1" stopOpacity={0.28} />
+                    <stop offset="70%" stopColor="#8b5cf6" stopOpacity={0.18} />
+                    <stop offset="100%" stopColor="#c084fc" stopOpacity={0.08} />
                   </linearGradient>
                 </defs>
                 <CartesianGrid strokeDasharray="4 4" stroke="#cbd5f5" vertical={false} />
@@ -1608,16 +1609,16 @@ const Calculator = () => {
                   dataKey="SunRun"
                   stroke="url(#sunrunLineGradient)"
                   strokeWidth={3.5}
-                  dot={{ r: 5.5, strokeWidth: 2, stroke: '#c7d2fe', fill: '#4338ca' }}
-                  activeDot={{ r: 8, strokeWidth: 0, fill: '#4338ca' }}
+                  dot={{ r: 6.25, strokeWidth: 2.5, stroke: '#c7d2fe', fill: '#312e81' }}
+                  activeDot={{ r: 9, strokeWidth: 0, fill: '#4338ca' }}
                 />
                 <Line
                   type="monotone"
                   dataKey="SCE"
                   stroke="url(#sceLineGradient)"
                   strokeWidth={3.5}
-                  dot={{ r: 5.5, strokeWidth: 2, stroke: '#fbcfe8', fill: '#be185d' }}
-                  activeDot={{ r: 8, strokeWidth: 0, fill: '#be185d' }}
+                  dot={{ r: 6.25, strokeWidth: 2.5, stroke: '#fbcfe8', fill: '#6d28d9' }}
+                  activeDot={{ r: 9, strokeWidth: 0, fill: '#7c3aed' }}
                 />
               </ComposedChart>
             </ResponsiveContainer>

--- a/src/Components/Calculator/styles.css
+++ b/src/Components/Calculator/styles.css
@@ -1694,6 +1694,26 @@ button:hover::after {
   }
 }
 
+.recharts-line-SunRun path {
+  filter: drop-shadow(0 0 8px rgba(99, 102, 241, 0.45));
+}
+
+.recharts-line-SCE path {
+  filter: drop-shadow(0 0 8px rgba(236, 72, 153, 0.4));
+}
+
+.recharts-line-SunRun .recharts-dot {
+  stroke: rgba(199, 210, 254, 0.95);
+  fill: #312e81;
+  filter: drop-shadow(0 2px 6px rgba(59, 130, 246, 0.45));
+}
+
+.recharts-line-SCE .recharts-dot {
+  stroke: rgba(251, 207, 232, 0.95);
+  fill: #6d28d9;
+  filter: drop-shadow(0 2px 6px rgba(217, 70, 239, 0.45));
+}
+
 @media (prefers-reduced-motion: reduce) {
   .animatable,
   .is-visible,


### PR DESCRIPTION
## Summary
- apply gradient strokes and a refreshed savings fill to the calculator chart
- align tooltip accents and dot styling with the updated palette
- add soft glows for Sunrun and SCE chart lines and points via CSS helpers

## Testing
- npm run start

------
https://chatgpt.com/codex/tasks/task_e_68d9c33a6eec8327b082a751439b15af