### PR TITLE
Add LADWP calculator toggle

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -47,6 +47,121 @@ body::after {
   animation: fadeInShell 1s ease forwards;
 }
 
+.app-shell__inner {
+  width: 100%;
+  max-width: 1180px;
+  display: flex;
+  flex-direction: column;
+  gap: clamp(18px, 4vw, 36px);
+  align-items: center;
+}
+
+.app-switcher {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
+  gap: 12px;
+  padding: 10px 14px;
+  background: rgba(255, 255, 255, 0.6);
+  border-radius: 999px;
+  border: 1px solid rgba(200, 170, 140, 0.35);
+  box-shadow: 0 18px 42px rgba(143, 106, 78, 0.2);
+  backdrop-filter: blur(10px);
+  position: sticky;
+  top: clamp(16px, 4vw, 32px);
+  z-index: 5;
+}
+
+.app-switcher__button {
+  border: none;
+  background: transparent;
+  font: inherit;
+  color: #5d4d43;
+  cursor: pointer;
+  padding: 12px 22px;
+  border-radius: 999px;
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 4px;
+  min-width: 180px;
+  text-align: left;
+  transition: background 0.3s ease, box-shadow 0.3s ease, transform 0.3s ease, color 0.3s ease;
+  position: relative;
+  isolation: isolate;
+}
+
+.app-switcher__button::after {
+  content: '';
+  position: absolute;
+  inset: 0;
+  border-radius: inherit;
+  background: linear-gradient(135deg, rgba(231, 111, 81, 0.18), rgba(42, 157, 143, 0.18));
+  opacity: 0;
+  transition: opacity 0.3s ease;
+  z-index: -1;
+}
+
+.app-switcher__button-label {
+  font-weight: 600;
+  font-size: 0.95rem;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+}
+
+.app-switcher__button-description {
+  font-size: 0.8rem;
+  color: inherit;
+  opacity: 0.8;
+}
+
+.app-switcher__button:is(:hover, :focus-visible) {
+  transform: translateY(-2px);
+  box-shadow: 0 16px 32px rgba(143, 106, 78, 0.24);
+}
+
+.app-switcher__button:is(:hover, :focus-visible)::after {
+  opacity: 1;
+}
+
+.app-switcher__button.is-active {
+  color: #fff;
+  box-shadow: 0 20px 36px rgba(231, 111, 81, 0.35);
+}
+
+.app-switcher__button.is-active::after {
+  opacity: 1;
+  background: linear-gradient(135deg, rgba(231, 111, 81, 0.92), rgba(42, 157, 143, 0.88));
+}
+
+.app-switcher__button:focus-visible {
+  outline: 3px solid rgba(42, 157, 143, 0.55);
+  outline-offset: 3px;
+}
+
+@media (max-width: 720px) {
+  .app-switcher {
+    flex-direction: column;
+    align-items: stretch;
+    position: static;
+  }
+
+  .app-switcher__button {
+    align-items: center;
+    text-align: center;
+    min-width: auto;
+    padding: 14px 18px;
+  }
+
+  .app-switcher__button-label {
+    font-size: 1rem;
+  }
+
+  .app-switcher__button-description {
+    font-size: 0.85rem;
+  }
+}
+
 .app-shell::before {
   content: '';
   position: absolute;

--- a/src/App.js
+++ b/src/App.js
@@ -1,10 +1,116 @@
+import { useEffect, useMemo, useState } from 'react'
 import './App.css'
 import Calculator from './Components/Calculator/calculator'
 
+const UTILITY_OPTIONS = [
+  {
+    id: 'sce',
+    label: 'SCE',
+    description: 'Southern California Edison'
+  },
+  {
+    id: 'ladwp',
+    label: 'LADWP',
+    description: 'Los Angeles Department of Water and Power'
+  }
+]
+
+const UTILITY_IDS = new Set(UTILITY_OPTIONS.map((option) => option.id))
+
+const getInitialUtility = () => {
+  if (typeof window === 'undefined') {
+    return 'sce'
+  }
+
+  const params = new URLSearchParams(window.location.search)
+  const fromQuery = params.get('utility')
+
+  if (fromQuery) {
+    const normalized = fromQuery.toLowerCase()
+
+    if (UTILITY_IDS.has(normalized)) {
+      return normalized
+    }
+  }
+
+  const hash = window.location.hash.replace('#', '').toLowerCase()
+
+  if (UTILITY_IDS.has(hash)) {
+    return hash
+  }
+
+  return 'sce'
+}
+
 function App() {
+  const [activeUtility, setActiveUtility] = useState(getInitialUtility)
+
+  useEffect(() => {
+    if (typeof window === 'undefined') {
+      return undefined
+    }
+
+    const handlePopState = () => {
+      const nextUtility = getInitialUtility()
+      setActiveUtility((prev) => (prev === nextUtility ? prev : nextUtility))
+    }
+
+    window.addEventListener('popstate', handlePopState)
+
+    return () => window.removeEventListener('popstate', handlePopState)
+  }, [])
+
+  useEffect(() => {
+    if (typeof window === 'undefined') {
+      return
+    }
+
+    const params = new URLSearchParams(window.location.search)
+    params.set('utility', activeUtility)
+
+    const search = params.toString()
+    const hash = window.location.hash
+    const nextUrl = `${window.location.pathname}${search ? `?${search}` : ''}${hash}`
+
+    window.history.replaceState(null, '', nextUrl)
+  }, [activeUtility])
+
+  const utilityTabs = useMemo(() => UTILITY_OPTIONS, [])
+
   return (
     <div className="app-shell">
-      <Calculator />
+      <div className="app-shell__inner">
+        <div className="app-switcher" role="tablist" aria-label="Utility calculators">
+          {utilityTabs.map((option) => {
+            const isActive = option.id === activeUtility
+
+            return (
+              <button
+                key={option.id}
+                type="button"
+                role="tab"
+                aria-selected={isActive}
+                className={`app-switcher__button${isActive ? ' is-active' : ''}`}
+                onClick={() => {
+                  if (!isActive) {
+                    setActiveUtility(option.id)
+                  }
+                }}
+              >
+                <span className="app-switcher__button-label">{option.label}</span>
+                <span className="app-switcher__button-description">{option.description}</span>
+              </button>
+            )
+          })}
+        </div>
+
+        <Calculator
+          key={activeUtility}
+          initialUtility={activeUtility}
+          allowUtilitySelection={false}
+          id={`${activeUtility}-calculator`}
+        />
+      </div>
     </div>
   )
 }

--- a/src/Components/Calculator/styles.css
+++ b/src/Components/Calculator/styles.css
@@ -272,16 +272,21 @@ body {
   gap: 8px;
 }
 
-.form-group input {
+.form-group input,
+.form-group select {
   padding: 14px 16px;
   font-size: 1rem;
   border-radius: 16px;
   border: 1px solid rgba(198, 168, 140, 0.42);
   transition: border-color 0.3s ease, box-shadow 0.3s ease;
   background: rgba(248, 242, 236, 0.92);
+  appearance: none;
+  -webkit-appearance: none;
+  -moz-appearance: none;
 }
 
-.form-group input:focus {
+.form-group input:focus,
+.form-group select:focus {
   outline: none;
   border-color: var(--color-accent);
   box-shadow: 0 0 0 4px rgba(231, 111, 81, 0.18);
@@ -298,6 +303,7 @@ body {
 }
 
 .form-group input.input-error,
+.form-group select.input-error,
 .sunrun-input-row input.input-error {
   border-color: #dc2626;
   box-shadow: 0 0 0 4px rgba(220, 38, 38, 0.12);
@@ -1666,7 +1672,7 @@ button:hover::after {
   filter: drop-shadow(0 0 8px rgba(63, 200, 179, 0.35));
 }
 
-.recharts-line-SCE path {
+.recharts-line-Utility path {
   filter: drop-shadow(0 0 8px rgba(240, 138, 107, 0.3));
 }
 
@@ -1677,7 +1683,7 @@ button:hover::after {
   filter: drop-shadow(0 0 6px rgba(100, 215, 199, 0.35));
 }
 
-.recharts-line-SCE .recharts-dot {
+.recharts-line-Utility .recharts-dot {
   fill: #f08a6b !important;
   stroke: rgba(252, 224, 212, 0.9) !important;
   stroke-width: 2px;
@@ -1796,7 +1802,7 @@ button:hover::after {
   filter: drop-shadow(0 0 8px rgba(42, 157, 143, 0.35));
 }
 
-.recharts-line-SCE path {
+.recharts-line-Utility path {
   filter: drop-shadow(0 0 8px rgba(231, 111, 81, 0.32));
 }
 
@@ -1806,7 +1812,7 @@ button:hover::after {
   filter: drop-shadow(0 2px 6px rgba(42, 157, 143, 0.35));
 }
 
-.recharts-line-SCE .recharts-dot {
+.recharts-line-Utility .recharts-dot {
   stroke: rgba(242, 201, 183, 0.92);
   fill: #b04932;
   filter: drop-shadow(0 2px 6px rgba(231, 111, 81, 0.35));


### PR DESCRIPTION
## Summary
- keep configurable utility metadata and defaults for SCE and LADWP while allowing calculators to be instantiated per utility
- add an app-level toggle so visitors can launch either the SCE or LADWP calculator without losing the existing SCE experience
- style the new toggle controls so the LADWP and SCE calculators feel cohesive with the existing layout

## Testing
- npm test -- --watch=false

------
https://chatgpt.com/codex/tasks/task_e_68d9dde9f8dc832786cd772fc324f7f1