### PR TITLE
feat: apply LADWP theme colors

### DIFF
--- a/src/Components/Calculator/calculator.js
+++ b/src/Components/Calculator/calculator.js
@@ -1027,7 +1027,7 @@ const Calculator = ({ initialUtility = 'sce', allowUtilitySelection = false, id 
   }, [animationTriggerKey])
 
   return (
-    <section id={id} className="calculator-container">
+    <section id={id} className="calculator-container" data-utility-theme={selectedUtility}>
       <div className="calculator-header animatable" data-animate>
         <span className="calculator-badge">Energy insights</span>
         <h1><span>Visualize</span> your {utilityShortName} costs with clarity</h1>
@@ -1774,27 +1774,27 @@ const Calculator = ({ initialUtility = 'sce', allowUtilitySelection = false, id 
                     <stop offset="100%" stopColor="rgba(100, 215, 199, 0.16)" />
                   </linearGradient>
                 </defs>
-                <CartesianGrid strokeDasharray="3 3" stroke="#e0d5c8" vertical={false} />
+                <CartesianGrid strokeDasharray="3 3" stroke="var(--chart-grid-stroke)" vertical={false} />
                 <XAxis
                   dataKey="year"
-                  tick={{ fontSize: 12, fontWeight: 600, fill: '#5a4c43' }}
+                  tick={{ fontSize: 12, fontWeight: 600, fill: 'var(--chart-axis-tick)' }}
                   angle={-30}
                   textAnchor="end"
                   interval={0}
                   height={70}
                   tickMargin={18}
-                  axisLine={{ stroke: '#d9cbb8' }}
-                  tickLine={{ stroke: '#d9cbb8' }}
+                  axisLine={{ stroke: 'var(--chart-axis-line)' }}
+                  tickLine={{ stroke: 'var(--chart-axis-line)' }}
                 />
                 <YAxis
                   tickFormatter={currencyFormatter}
-                  tick={{ fontSize: 12, fontWeight: 600, fill: '#5a4c43' }}
+                  tick={{ fontSize: 12, fontWeight: 600, fill: 'var(--chart-axis-tick)' }}
                   width={90}
                   tickMargin={16}
-                  axisLine={{ stroke: '#d9cbb8' }}
-                  tickLine={{ stroke: '#d9cbb8' }}
+                  axisLine={{ stroke: 'var(--chart-axis-line)' }}
+                  tickLine={{ stroke: 'var(--chart-axis-line)' }}
                 />
-                <Tooltip content={renderChartTooltip} cursor={{ strokeDasharray: '4 2', stroke: '#d7b89a' }} />
+                <Tooltip content={renderChartTooltip} cursor={{ strokeDasharray: '4 2', stroke: 'var(--chart-tooltip-cursor)' }} />
                 {isDesktop && (
                   <Legend
                     verticalAlign="top"
@@ -1808,9 +1808,9 @@ const Calculator = ({ initialUtility = 'sce', allowUtilitySelection = false, id 
                   <>
                     <ReferenceLine
                       x={breakEvenYear}
-                      stroke="#b07a5b"
+                      stroke="var(--chart-reference-line)"
                       strokeDasharray="4 4"
-                      label={{ value: 'Break-even', position: 'insideTop', fill: '#b07a5b', fontSize: 12 }}
+                      label={{ value: 'Break-even', position: 'insideTop', fill: 'var(--chart-reference-label)', fontSize: 12 }}
                     />
                     {breakEvenPoint && (
                       <>

--- a/src/Components/Calculator/styles.css
+++ b/src/Components/Calculator/styles.css
@@ -12,6 +12,24 @@
   --color-emerald: #90be6d;
   --color-clay: #b07a5b;
   --shadow-soft: rgba(68, 50, 32, 0.12);
+  --color-pill-bg: rgba(236, 224, 210, 0.7);
+  --color-pill-text: #5d4d43;
+  --shadow-pill: rgba(96, 74, 54, 0.16);
+  --shadow-pill-hover: rgba(96, 74, 54, 0.22);
+  --color-card-border: rgba(200, 170, 140, 0.32);
+  --color-card-border-hover: rgba(231, 111, 81, 0.28);
+  --color-card-border-inner: rgba(200, 170, 140, 0.24);
+  --shadow-card: rgba(125, 92, 65, 0.16);
+  --shadow-card-hover: rgba(125, 92, 65, 0.2);
+  --color-surface-glow: rgba(231, 111, 81, 0.2);
+  --chart-grid-stroke: #e0d5c8;
+  --chart-axis-line: #d9cbb8;
+  --chart-axis-tick: #5a4c43;
+  --chart-tooltip-cursor: #d7b89a;
+  --chart-reference-line: #b07a5b;
+  --chart-reference-label: #b07a5b;
+  --shadow-badge: rgba(183, 109, 76, 0.28);
+  --badge-highlight: rgba(244, 162, 97, 0.4);
 }
 
 body {
@@ -46,6 +64,38 @@ body {
   position: relative;
 }
 
+.calculator-container[data-utility-theme='ladwp'] {
+  --color-ink: #132043;
+  --color-muted: #4a5d8c;
+  --color-soft: #f0f4ff;
+  --color-soft-strong: #dbe6ff;
+  --color-accent: #3f72ff;
+  --color-accent-soft: rgba(63, 114, 255, 0.18);
+  --color-accent-secondary: #23b7ff;
+  --color-accent-tertiary: #7fa5ff;
+  --color-emerald: #2ec5ff;
+  --color-clay: #4d7bff;
+  --shadow-soft: rgba(19, 32, 67, 0.12);
+  --color-pill-bg: rgba(214, 226, 255, 0.85);
+  --color-pill-text: #1f2f5c;
+  --shadow-pill: rgba(47, 79, 132, 0.18);
+  --shadow-pill-hover: rgba(47, 79, 132, 0.28);
+  --color-card-border: rgba(120, 160, 250, 0.32);
+  --color-card-border-inner: rgba(120, 160, 250, 0.24);
+  --color-card-border-hover: rgba(63, 114, 255, 0.32);
+  --shadow-card: rgba(40, 80, 160, 0.18);
+  --shadow-card-hover: rgba(40, 80, 160, 0.24);
+  --color-surface-glow: rgba(63, 114, 255, 0.18);
+  --chart-grid-stroke: #d6e2ff;
+  --chart-axis-line: #bccaf5;
+  --chart-axis-tick: #233b73;
+  --chart-tooltip-cursor: #a8bbf3;
+  --chart-reference-line: #2e5ce6;
+  --chart-reference-label: #2e5ce6;
+  --shadow-badge: rgba(40, 80, 160, 0.22);
+  --badge-highlight: rgba(124, 163, 255, 0.42);
+}
+
 .calculator-header {
   text-align: center;
   display: flex;
@@ -64,7 +114,7 @@ body {
   border-radius: 999px;
   text-transform: uppercase;
   letter-spacing: 0.08em;
-  box-shadow: 0 10px 28px rgba(183, 109, 76, 0.28);
+  box-shadow: 0 10px 28px var(--shadow-badge);
   backdrop-filter: blur(6px);
   position: relative;
   overflow: hidden;
@@ -75,7 +125,7 @@ body {
   content: '';
   position: absolute;
   inset: 0;
-  background: radial-gradient(circle at 30% 30%, rgba(244, 162, 97, 0.4), transparent 60%);
+  background: radial-gradient(circle at 30% 30%, var(--badge-highlight), transparent 60%);
   opacity: 0;
   transition: opacity 0.4s ease;
 }
@@ -119,17 +169,17 @@ body {
 .header-pills span {
   padding: 6px 12px;
   border-radius: 999px;
-  background: rgba(236, 224, 210, 0.7);
-  color: #5d4d43;
+  background: var(--color-pill-bg);
+  color: var(--color-pill-text);
   font-size: 0.85rem;
   letter-spacing: 0.02em;
   transition: transform 0.3s ease, box-shadow 0.3s ease;
-  box-shadow: 0 6px 16px rgba(96, 74, 54, 0.16);
+  box-shadow: 0 6px 16px var(--shadow-pill);
 }
 
 .header-pills span:hover {
   transform: translateY(-3px);
-  box-shadow: 0 12px 24px rgba(96, 74, 54, 0.22);
+  box-shadow: 0 12px 24px var(--shadow-pill-hover);
 }
 
 .calculator-grid {
@@ -154,8 +204,8 @@ body {
   background: rgba(255, 255, 255, 0.94);
   border-radius: 24px;
   padding: clamp(24px, 2.8vw, 32px);
-  border: 1px solid rgba(200, 170, 140, 0.32);
-  box-shadow: 0 25px 55px rgba(125, 92, 65, 0.16);
+  border: 1px solid var(--color-card-border);
+  box-shadow: 0 25px 55px var(--shadow-card);
   backdrop-filter: blur(14px);
   position: relative;
   overflow: hidden;
@@ -170,7 +220,7 @@ body {
   inset: -40% -35% auto auto;
   height: 220px;
   width: 220px;
-  background: radial-gradient(circle at center, rgba(231, 111, 81, 0.2), transparent 65%);
+  background: radial-gradient(circle at center, var(--color-surface-glow), transparent 65%);
   opacity: 0.6;
   z-index: -1;
   transform: rotate(12deg);
@@ -181,7 +231,7 @@ body {
   position: absolute;
   inset: 1px;
   border-radius: inherit;
-  border: 1px solid rgba(200, 170, 140, 0.24);
+  border: 1px solid var(--color-card-border-inner);
   background: linear-gradient(135deg, rgba(255, 255, 255, 0.18), rgba(255, 255, 255, 0));
   z-index: -2;
   pointer-events: none;
@@ -189,8 +239,8 @@ body {
 
 .surface-card:hover {
   transform: translateY(-8px);
-  box-shadow: 0 32px 65px rgba(125, 92, 65, 0.2);
-  border-color: rgba(231, 111, 81, 0.28);
+  box-shadow: 0 32px 65px var(--shadow-card-hover);
+  border-color: var(--color-card-border-hover);
 }
 
 .form-header {


### PR DESCRIPTION
## Summary
- add a utility theme data attribute to the calculator shell so styles can react to LADWP selections
- extend the calculator stylesheet with reusable color variables and a cool-toned LADWP palette override
- update chart rendering to pull axis and reference colors from CSS variables for theme awareness

## Testing
- npm test -- --watchAll=false

------
https://chatgpt.com/codex/tasks/task_e_68d9f1c6be108327a042b158ea8a2cfd