### PR TITLE
Persist calculator inputs in URL and add share link

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -66,13 +66,25 @@ function App() {
     }
 
     const params = new URLSearchParams(window.location.search)
+    const currentUtility = params.get('utility')
+
+    if (currentUtility === activeUtility) {
+      return
+    }
+
     params.set('utility', activeUtility)
 
     const search = params.toString()
     const hash = window.location.hash
     const nextUrl = `${window.location.pathname}${search ? `?${search}` : ''}${hash}`
 
-    window.history.replaceState(null, '', nextUrl)
+    const currentSearch = window.location.search.startsWith('?')
+      ? window.location.search.slice(1)
+      : window.location.search
+
+    if (search !== currentSearch) {
+      window.history.replaceState(null, '', nextUrl)
+    }
   }, [activeUtility])
 
   const utilityTabs = useMemo(() => UTILITY_OPTIONS, [])


### PR DESCRIPTION
## Summary
- initialize calculator inputs from URL parameters and persist changes back to the query string with a debounce
- ensure the app-level utility parameter update preserves calculator parameters and add a "Copy share link" action near projection controls

## Testing
- npm test -- --watchAll=false

------
https://chatgpt.com/codex/tasks/task_e_68d9fc12a2dc8327bef8dc6656828917