### PR TITLE
Refine utility toggle styling

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -56,17 +56,18 @@ body::after {
   align-items: center;
 }
 
+
 .app-switcher {
   display: flex;
   flex-wrap: wrap;
   justify-content: center;
-  gap: 12px;
-  padding: 10px 14px;
-  background: rgba(255, 255, 255, 0.6);
-  border-radius: 999px;
-  border: 1px solid rgba(200, 170, 140, 0.35);
-  box-shadow: 0 18px 42px rgba(143, 106, 78, 0.2);
-  backdrop-filter: blur(10px);
+  gap: 8px;
+  padding: 6px 8px;
+  background: rgba(255, 255, 255, 0.68);
+  border-radius: 18px;
+  border: 1px solid rgba(200, 170, 140, 0.28);
+  box-shadow: 0 14px 30px rgba(143, 106, 78, 0.18);
+  backdrop-filter: blur(12px);
   position: sticky;
   top: clamp(16px, 4vw, 32px);
   z-index: 5;
@@ -78,17 +79,17 @@ body::after {
   font: inherit;
   color: #5d4d43;
   cursor: pointer;
-  padding: 12px 22px;
-  border-radius: 999px;
-  display: flex;
-  flex-direction: column;
-  align-items: flex-start;
-  gap: 4px;
-  min-width: 180px;
+  padding: 10px 16px;
+  border-radius: 14px;
+  display: grid;
+  grid-template-columns: auto;
+  gap: 2px;
+  min-width: 140px;
   text-align: left;
-  transition: background 0.3s ease, box-shadow 0.3s ease, transform 0.3s ease, color 0.3s ease;
+  transition: background 0.3s ease, box-shadow 0.3s ease, transform 0.25s ease, color 0.3s ease;
   position: relative;
   isolation: isolate;
+  border: 1px solid transparent;
 }
 
 .app-switcher__button::after {
@@ -96,7 +97,7 @@ body::after {
   position: absolute;
   inset: 0;
   border-radius: inherit;
-  background: linear-gradient(135deg, rgba(231, 111, 81, 0.18), rgba(42, 157, 143, 0.18));
+  background: linear-gradient(135deg, rgba(231, 111, 81, 0.16), rgba(42, 157, 143, 0.16));
   opacity: 0;
   transition: opacity 0.3s ease;
   z-index: -1;
@@ -104,20 +105,21 @@ body::after {
 
 .app-switcher__button-label {
   font-weight: 600;
-  font-size: 0.95rem;
-  letter-spacing: 0.04em;
+  font-size: 0.85rem;
+  letter-spacing: 0.05em;
   text-transform: uppercase;
 }
 
 .app-switcher__button-description {
-  font-size: 0.8rem;
+  font-size: 0.72rem;
   color: inherit;
-  opacity: 0.8;
+  opacity: 0.75;
 }
 
 .app-switcher__button:is(:hover, :focus-visible) {
-  transform: translateY(-2px);
-  box-shadow: 0 16px 32px rgba(143, 106, 78, 0.24);
+  transform: translateY(-1px);
+  box-shadow: 0 12px 24px rgba(143, 106, 78, 0.2);
+  border-color: rgba(231, 111, 81, 0.32);
 }
 
 .app-switcher__button:is(:hover, :focus-visible)::after {
@@ -126,12 +128,12 @@ body::after {
 
 .app-switcher__button.is-active {
   color: #fff;
-  box-shadow: 0 20px 36px rgba(231, 111, 81, 0.35);
+  box-shadow: 0 16px 28px rgba(231, 111, 81, 0.32);
 }
 
 .app-switcher__button.is-active::after {
   opacity: 1;
-  background: linear-gradient(135deg, rgba(231, 111, 81, 0.92), rgba(42, 157, 143, 0.88));
+  background: linear-gradient(135deg, rgba(231, 111, 81, 0.9), rgba(42, 157, 143, 0.88));
 }
 
 .app-switcher__button:focus-visible {
@@ -144,21 +146,22 @@ body::after {
     flex-direction: column;
     align-items: stretch;
     position: static;
+    padding: 10px;
   }
 
   .app-switcher__button {
-    align-items: center;
     text-align: center;
     min-width: auto;
-    padding: 14px 18px;
+    padding: 12px 18px;
+    border-radius: 16px;
   }
 
   .app-switcher__button-label {
-    font-size: 1rem;
+    font-size: 0.95rem;
   }
 
   .app-switcher__button-description {
-    font-size: 0.85rem;
+    font-size: 0.78rem;
   }
 }
 


### PR DESCRIPTION
## Summary
- soften the utility switcher container and reduce spacing for a sleeker look
- adjust button typography, borders, and hover states to create a compact segmented control feel
- update responsive spacing so the smaller styling carries over on mobile

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68da0476c4e883278c95518806c295be