### PR TITLE
Improve dark theme readability

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -42,40 +42,40 @@
 
 :root[data-theme='dark'] {
   color-scheme: dark;
-  --app-text-color: #f6eee4;
-  --app-background: linear-gradient(160deg, #1c1814 0%, #221c17 46%, #2a221b 100%);
+  --app-text-color: #f8f2ea;
+  --app-background: linear-gradient(160deg, #221b16 0%, #2a221c 46%, #322921 100%);
   --app-blob-primary: radial-gradient(
     circle at center,
-    rgba(231, 111, 81, 0.26) 0%,
-    rgba(231, 111, 81, 0.08) 65%,
+    rgba(231, 111, 81, 0.32) 0%,
+    rgba(231, 111, 81, 0.12) 65%,
     transparent 75%
   );
   --app-blob-secondary: radial-gradient(
     circle at center,
-    rgba(64, 181, 164, 0.28) 0%,
-    rgba(64, 181, 164, 0.1) 65%,
+    rgba(64, 181, 164, 0.32) 0%,
+    rgba(64, 181, 164, 0.14) 65%,
     transparent 75%
   );
-  --app-shell-highlight: linear-gradient(120deg, rgba(60, 48, 40, 0.6), transparent 60%);
-  --app-shell-grid: radial-gradient(rgba(78, 63, 53, 0.45) 1px, transparent 0);
-  --app-switcher-bg: rgba(36, 30, 26, 0.88);
-  --app-switcher-border: rgba(124, 96, 72, 0.55);
-  --app-switcher-shadow: rgba(18, 12, 8, 0.36);
-  --app-switcher-hover-shadow: rgba(18, 12, 8, 0.48);
-  --app-switcher-hover-border: rgba(231, 111, 81, 0.42);
-  --app-switcher-color: #f6eee4;
-  --app-switcher-focus-outline: rgba(64, 181, 164, 0.6);
+  --app-shell-highlight: linear-gradient(120deg, rgba(72, 56, 46, 0.6), transparent 60%);
+  --app-shell-grid: radial-gradient(rgba(92, 74, 62, 0.48) 1px, transparent 0);
+  --app-switcher-bg: rgba(42, 34, 30, 0.9);
+  --app-switcher-border: rgba(148, 118, 92, 0.55);
+  --app-switcher-shadow: rgba(12, 8, 6, 0.4);
+  --app-switcher-hover-shadow: rgba(12, 8, 6, 0.52);
+  --app-switcher-hover-border: rgba(231, 111, 81, 0.48);
+  --app-switcher-color: #f8f2ea;
+  --app-switcher-focus-outline: rgba(82, 204, 186, 0.65);
   --app-switcher-active-text: #fdf8f4;
   --app-switcher-active-gradient: linear-gradient(
     135deg,
-    rgba(242, 132, 92, 0.95),
-    rgba(64, 181, 164, 0.9)
+    rgba(242, 132, 92, 0.98),
+    rgba(73, 197, 179, 0.92)
   );
-  --app-theme-toggle-bg: rgba(36, 30, 26, 0.78);
-  --app-theme-toggle-border: rgba(124, 96, 72, 0.62);
-  --app-theme-toggle-shadow: rgba(8, 6, 4, 0.6);
-  --app-theme-toggle-color: #f6eee4;
-  --app-theme-toggle-hover-bg: rgba(52, 42, 36, 0.94);
+  --app-theme-toggle-bg: rgba(44, 36, 32, 0.82);
+  --app-theme-toggle-border: rgba(148, 118, 92, 0.65);
+  --app-theme-toggle-shadow: rgba(8, 6, 4, 0.64);
+  --app-theme-toggle-color: #f8f2ea;
+  --app-theme-toggle-hover-bg: rgba(60, 48, 40, 0.96);
 }
 
 body {

--- a/src/Components/Calculator/styles.css
+++ b/src/Components/Calculator/styles.css
@@ -50,10 +50,10 @@
 
 :root[data-theme='dark'] {
   color-scheme: dark;
-  --color-ink: #f6eee4;
-  --color-muted: #c7b5a5;
-  --color-soft: #2e2621;
-  --color-soft-strong: #3a3029;
+  --color-ink: #f7f0e8;
+  --color-muted: #d9c5b3;
+  --color-soft: #392f28;
+  --color-soft-strong: #453830;
   --color-accent: #f2845c;
   --color-accent-soft: rgba(242, 132, 92, 0.24);
   --color-accent-secondary: #49c5b3;
@@ -61,16 +61,16 @@
   --color-emerald: #9ed081;
   --color-clay: #d08b63;
   --shadow-soft: rgba(0, 0, 0, 0.35);
-  --color-pill-bg: rgba(58, 48, 40, 0.85);
-  --color-pill-text: #f5e8dc;
+  --color-pill-bg: rgba(68, 56, 47, 0.88);
+  --color-pill-text: #f6ece1;
   --shadow-pill: rgba(0, 0, 0, 0.38);
   --shadow-pill-hover: rgba(0, 0, 0, 0.45);
-  --color-card-border: rgba(124, 96, 72, 0.45);
-  --color-card-border-hover: rgba(242, 132, 92, 0.6);
-  --color-card-border-inner: rgba(124, 96, 72, 0.36);
-  --shadow-card: rgba(0, 0, 0, 0.5);
-  --shadow-card-hover: rgba(0, 0, 0, 0.6);
-  --color-surface-glow: rgba(242, 132, 92, 0.32);
+  --color-card-border: rgba(148, 118, 92, 0.55);
+  --color-card-border-hover: rgba(242, 132, 92, 0.65);
+  --color-card-border-inner: rgba(148, 118, 92, 0.4);
+  --shadow-card: rgba(0, 0, 0, 0.48);
+  --shadow-card-hover: rgba(0, 0, 0, 0.58);
+  --color-surface-glow: rgba(242, 132, 92, 0.36);
   --chart-grid-stroke: #473830;
   --chart-axis-line: #5a453a;
   --chart-axis-tick: #f0e5d8;
@@ -79,22 +79,22 @@
   --chart-reference-label: #f6b37c;
   --shadow-badge: rgba(0, 0, 0, 0.42);
   --badge-highlight: rgba(242, 132, 92, 0.38);
-  --surface-card-background: linear-gradient(135deg, rgba(48, 39, 33, 0.94), rgba(36, 29, 25, 0.96));
-  --form-control-background: rgba(44, 36, 31, 0.92);
-  --form-control-border: rgba(132, 101, 78, 0.6);
-  --form-control-focus-shadow: rgba(242, 132, 92, 0.26);
-  --reset-button-background: rgba(255, 255, 255, 0.08);
-  --reset-button-hover-background: rgba(255, 255, 255, 0.14);
-  --sunrun-input-background: linear-gradient(135deg, rgba(66, 53, 43, 0.8), rgba(40, 52, 50, 0.78));
-  --sunrun-input-border: rgba(132, 101, 78, 0.55);
-  --sunrun-focus-shadow: rgba(73, 197, 179, 0.26);
-  --bill-card-background: linear-gradient(135deg, rgba(48, 39, 33, 0.94), rgba(32, 37, 38, 0.96));
-  --bill-card-border: rgba(124, 96, 72, 0.5);
-  --bill-card-border-hover: rgba(124, 96, 72, 0.65);
-  --bill-card-shadow: rgba(0, 0, 0, 0.55);
-  --bill-card-shadow-hover: rgba(0, 0, 0, 0.66);
-  --bill-card-soft: rgba(120, 145, 165, 0.14);
-  --bill-card-glow: rgba(124, 96, 72, 0.32);
+  --surface-card-background: linear-gradient(135deg, rgba(58, 47, 40, 0.92), rgba(42, 34, 29, 0.95));
+  --form-control-background: rgba(54, 44, 37, 0.94);
+  --form-control-border: rgba(148, 118, 92, 0.62);
+  --form-control-focus-shadow: rgba(242, 132, 92, 0.32);
+  --reset-button-background: rgba(255, 255, 255, 0.12);
+  --reset-button-hover-background: rgba(255, 255, 255, 0.18);
+  --sunrun-input-background: linear-gradient(135deg, rgba(74, 60, 50, 0.86), rgba(46, 60, 58, 0.82));
+  --sunrun-input-border: rgba(148, 118, 92, 0.6);
+  --sunrun-focus-shadow: rgba(73, 197, 179, 0.32);
+  --bill-card-background: linear-gradient(135deg, rgba(62, 51, 43, 0.92), rgba(46, 54, 56, 0.9));
+  --bill-card-border: rgba(148, 118, 92, 0.58);
+  --bill-card-border-hover: rgba(148, 118, 92, 0.72);
+  --bill-card-shadow: rgba(0, 0, 0, 0.52);
+  --bill-card-shadow-hover: rgba(0, 0, 0, 0.62);
+  --bill-card-soft: rgba(148, 163, 184, 0.22);
+  --bill-card-glow: rgba(148, 118, 92, 0.36);
 }
 
 body {


### PR DESCRIPTION
## Summary
- tune the application shell's dark theme palette for better contrast
- brighten calculator dark theme tokens so forms and bill cards remain legible after running a calculation

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68da0b6f59388327b6ee09ddcba0e364