### PR TITLE
Improve dark theme readability

### DIFF
--- a/src/Components/Calculator/styles.css
+++ b/src/Components/Calculator/styles.css
@@ -1899,6 +1899,289 @@ button:hover::after {
   filter: drop-shadow(0 0 8px rgba(63, 200, 179, 0.35));
 }
 
+:root[data-theme='dark'] .sunrun-input-container {
+  background: linear-gradient(135deg, rgba(21, 30, 48, 0.95), rgba(12, 25, 40, 0.92));
+  border-color: rgba(148, 163, 184, 0.45);
+  box-shadow: inset 0 1px 0 rgba(15, 23, 42, 0.65);
+}
+
+:root[data-theme='dark'] .sunrun-input-row input {
+  box-shadow: inset 0 1px 0 rgba(2, 6, 23, 0.75);
+}
+
+:root[data-theme='dark'] .sunrun-input-row input:focus {
+  border-color: rgba(56, 189, 248, 0.65);
+}
+
+:root[data-theme='dark'] .insight-card {
+  background: linear-gradient(135deg, rgba(15, 23, 42, 0.94), rgba(30, 41, 59, 0.9));
+  border-color: rgba(148, 163, 184, 0.45);
+  box-shadow: 0 24px 48px rgba(2, 6, 23, 0.68);
+}
+
+:root[data-theme='dark'] .insight-card:hover {
+  box-shadow: 0 28px 56px rgba(2, 6, 23, 0.75);
+}
+
+:root[data-theme='dark'] .insight-label {
+  color: rgba(148, 163, 184, 0.78);
+}
+
+:root[data-theme='dark'] .accent-blue {
+  border-color: rgba(56, 189, 248, 0.55);
+  background: linear-gradient(135deg, rgba(15, 23, 42, 0.96), rgba(30, 41, 59, 0.9));
+  box-shadow: 0 26px 52px rgba(3, 12, 33, 0.75);
+}
+
+:root[data-theme='dark'] .accent-emerald {
+  border-color: rgba(34, 211, 238, 0.55);
+  background: linear-gradient(135deg, rgba(15, 23, 42, 0.95), rgba(17, 94, 89, 0.32));
+  box-shadow: 0 26px 52px rgba(3, 12, 33, 0.75);
+}
+
+:root[data-theme='dark'] .accent-amber {
+  border-color: rgba(248, 196, 113, 0.55);
+  background: linear-gradient(135deg, rgba(15, 23, 42, 0.95), rgba(120, 53, 15, 0.35));
+  box-shadow: 0 26px 52px rgba(3, 12, 33, 0.75);
+}
+
+:root[data-theme='dark'] .accent-violet {
+  border-color: rgba(129, 140, 248, 0.5);
+  background: linear-gradient(135deg, rgba(17, 24, 39, 0.96), rgba(76, 29, 149, 0.36));
+  color: var(--color-ink);
+}
+
+:root[data-theme='dark'] .accent-slate {
+  border-color: rgba(148, 163, 184, 0.5);
+  background: linear-gradient(135deg, rgba(15, 23, 42, 0.95), rgba(71, 85, 105, 0.32));
+}
+
+:root[data-theme='dark'] .accent-indigo {
+  border-color: rgba(96, 165, 250, 0.55);
+  background: linear-gradient(135deg, rgba(15, 23, 42, 0.95), rgba(37, 99, 235, 0.28));
+}
+
+:root[data-theme='dark'] .empty-state {
+  background: rgba(15, 23, 42, 0.9);
+  border-color: rgba(148, 163, 184, 0.4);
+}
+
+:root[data-theme='dark'] .empty-state::before {
+  background: radial-gradient(circle at center, rgba(56, 189, 248, 0.24), transparent 65%);
+  opacity: 0.45;
+}
+
+:root[data-theme='dark'] .empty-state::after {
+  background: radial-gradient(circle at center, rgba(129, 140, 248, 0.22), transparent 65%);
+  opacity: 0.45;
+}
+
+:root[data-theme='dark'] .chart-card {
+  background: linear-gradient(145deg, rgba(15, 23, 42, 0.95), rgba(30, 41, 59, 0.9));
+  border-color: rgba(148, 163, 184, 0.45);
+  box-shadow: 0 35px 65px rgba(2, 6, 23, 0.72);
+}
+
+:root[data-theme='dark'] .chart-card::before {
+  background: radial-gradient(circle at center, rgba(56, 189, 248, 0.32), rgba(15, 23, 42, 0) 70%);
+}
+
+:root[data-theme='dark'] .chart-card::after {
+  background: radial-gradient(circle at center, rgba(129, 140, 248, 0.26), rgba(15, 23, 42, 0) 70%);
+}
+
+:root[data-theme='dark'] .chart-card:hover {
+  box-shadow: 0 40px 70px rgba(2, 6, 23, 0.78);
+  border-color: rgba(96, 165, 250, 0.55);
+}
+
+:root[data-theme='dark'] .yearly-breakdown-card {
+  background: radial-gradient(circle at top left, rgba(56, 189, 248, 0.18), transparent 60%);
+}
+
+:root[data-theme='dark'] .yearly-breakdown__table {
+  border-color: rgba(51, 65, 85, 0.8);
+}
+
+:root[data-theme='dark'] .yearly-breakdown__table thead th {
+  background: rgba(30, 41, 59, 0.85);
+}
+
+:root[data-theme='dark'] .yearly-breakdown__table tbody tr:nth-child(even) {
+  background: rgba(17, 24, 39, 0.72);
+}
+
+:root[data-theme='dark'] .yearly-breakdown__table tfoot th,
+:root[data-theme='dark'] .yearly-breakdown__table tfoot td {
+  background: rgba(56, 189, 248, 0.18);
+}
+
+:root[data-theme='dark'] .yearly-breakdown__rate-change {
+  color: rgba(148, 163, 184, 0.8);
+}
+
+:root[data-theme='dark'] .savings-summary {
+  background: linear-gradient(135deg, rgba(17, 24, 39, 0.95), rgba(30, 41, 59, 0.9));
+  border-color: rgba(148, 163, 184, 0.45);
+  box-shadow: 0 32px 64px rgba(2, 6, 23, 0.7);
+}
+
+:root[data-theme='dark'] .savings-summary:hover {
+  box-shadow: 0 38px 72px rgba(2, 6, 23, 0.78);
+}
+
+:root[data-theme='dark'] .savings-summary__badge {
+  background: rgba(56, 189, 248, 0.22);
+  color: var(--color-accent);
+  box-shadow: 0 12px 26px rgba(3, 12, 33, 0.55);
+}
+
+:root[data-theme='dark'] .metric-chip {
+  background: rgba(17, 24, 39, 0.92);
+  border-color: rgba(148, 163, 184, 0.4);
+  box-shadow: 0 22px 44px rgba(2, 6, 23, 0.68);
+}
+
+:root[data-theme='dark'] .metric-chip__icon {
+  background: linear-gradient(135deg, rgba(56, 189, 248, 0.28), rgba(129, 140, 248, 0.18));
+}
+
+:root[data-theme='dark'] .metric-chip__value span {
+  color: var(--color-accent-secondary);
+}
+
+:root[data-theme='dark'] .assumption-panel {
+  background: linear-gradient(135deg, rgba(17, 24, 39, 0.95), rgba(30, 41, 59, 0.88));
+  border-color: rgba(148, 163, 184, 0.4);
+  box-shadow: 0 28px 56px rgba(2, 6, 23, 0.7);
+}
+
+:root[data-theme='dark'] .assumption-metric {
+  background: rgba(17, 24, 39, 0.92);
+  border-color: rgba(148, 163, 184, 0.38);
+  box-shadow: 0 18px 36px rgba(2, 6, 23, 0.65);
+}
+
+:root[data-theme='dark'] .assumption-metric__label {
+  color: rgba(148, 163, 184, 0.75);
+}
+
+:root[data-theme='dark'] .homeowner-snapshot {
+  background: linear-gradient(135deg, rgba(17, 24, 39, 0.95), rgba(30, 41, 59, 0.9));
+  border-color: rgba(148, 163, 184, 0.42);
+  box-shadow: 0 32px 64px rgba(2, 6, 23, 0.7);
+}
+
+:root[data-theme='dark'] .homeowner-snapshot__badge {
+  background: rgba(56, 189, 248, 0.2);
+  color: var(--color-accent);
+}
+
+:root[data-theme='dark'] .snapshot-tile {
+  background: rgba(15, 23, 42, 0.9);
+  border-color: rgba(148, 163, 184, 0.42);
+  box-shadow: 0 22px 44px rgba(2, 6, 23, 0.68);
+}
+
+:root[data-theme='dark'] .snapshot-tile::after {
+  background: radial-gradient(circle at center, rgba(56, 189, 248, 0.24), transparent 70%);
+}
+
+:root[data-theme='dark'] .snapshot-tile__label {
+  color: rgba(148, 163, 184, 0.75);
+}
+
+:root[data-theme='dark'] .snapshot-tile__value-detail {
+  color: rgba(129, 140, 248, 0.78);
+}
+
+:root[data-theme='dark'] .snapshot-tile__caption,
+:root[data-theme='dark'] .snapshot-tile__note {
+  color: rgba(203, 213, 225, 0.82);
+}
+
+:root[data-theme='dark'] .scenario-panel {
+  background: linear-gradient(140deg, rgba(17, 24, 39, 0.95), rgba(30, 41, 59, 0.9));
+  border-color: rgba(148, 163, 184, 0.42);
+  box-shadow: 0 34px 68px rgba(2, 6, 23, 0.72);
+}
+
+:root[data-theme='dark'] .scenario-panel__badge {
+  background: rgba(129, 140, 248, 0.24);
+  color: var(--color-accent-secondary);
+}
+
+:root[data-theme='dark'] .scenario-card {
+  background: rgba(15, 23, 42, 0.92);
+  border-color: rgba(148, 163, 184, 0.4);
+  box-shadow: 0 28px 58px rgba(2, 6, 23, 0.7);
+}
+
+:root[data-theme='dark'] .scenario-card::after {
+  background: radial-gradient(circle at center, rgba(56, 189, 248, 0.25), transparent 70%);
+}
+
+:root[data-theme='dark'] .scenario-card__chip {
+  background: rgba(56, 189, 248, 0.2);
+  color: var(--color-accent-secondary);
+}
+
+:root[data-theme='dark'] .scenario-metric {
+  background: rgba(15, 23, 42, 0.9);
+  border-color: rgba(148, 163, 184, 0.4);
+}
+
+:root[data-theme='dark'] .scenario-metric__label {
+  color: rgba(148, 163, 184, 0.75);
+}
+
+:root[data-theme='dark'] .chart-controls {
+  background: rgba(30, 41, 59, 0.85);
+  border-color: rgba(96, 165, 250, 0.45);
+}
+
+:root[data-theme='dark'] .chart-wrapper::after {
+  background: radial-gradient(circle at top right, rgba(56, 189, 248, 0.18), transparent 55%),
+    radial-gradient(circle at bottom left, rgba(129, 140, 248, 0.18), transparent 60%);
+  mix-blend-mode: normal;
+}
+
+:root[data-theme='dark'] .chart-tooltip {
+  background: rgba(15, 23, 42, 0.95);
+  border-color: rgba(96, 165, 250, 0.45);
+  box-shadow: 0 26px 52px rgba(2, 6, 23, 0.72);
+  color: var(--color-ink);
+}
+
+:root[data-theme='dark'] .chart-tooltip__label {
+  color: rgba(148, 163, 184, 0.8);
+}
+
+:root[data-theme='dark'] .chart-tooltip__item::before {
+  box-shadow: 0 0 0 3px rgba(56, 189, 248, 0.24);
+}
+
+:root[data-theme='dark'] .chart-tooltip__rate-row span:first-child {
+  color: rgba(148, 163, 184, 0.82);
+}
+
+:root[data-theme='dark'] .chart-tooltip__rate-change {
+  color: rgba(129, 140, 248, 0.78);
+}
+
+:root[data-theme='dark'] .chart-tooltip__rate-change[data-direction='up'] {
+  color: rgba(34, 211, 238, 0.85);
+}
+
+:root[data-theme='dark'] .chart-tooltip__rate-change[data-direction='down'] {
+  color: rgba(248, 113, 113, 0.78);
+}
+
+:root[data-theme='dark'] .chart-tooltip__savings {
+  background: rgba(56, 189, 248, 0.18);
+  color: #7dd3fc;
+}
+
 .recharts-line-Utility path {
   filter: drop-shadow(0 0 8px rgba(240, 138, 107, 0.3));
 }


### PR DESCRIPTION
## Summary
- add dark theme specific styles for calculator cards, tables, controls, and tooltips
- ensure accent surfaces, inputs, and badges use higher contrast palettes in dark mode

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68dabbe890dc83278f84ea8df719e3a9